### PR TITLE
Removed character validation for ims command input

### DIFF
--- a/plugins/module_utils/ims_command_utils.py
+++ b/plugins/module_utils/ims_command_utils.py
@@ -3,7 +3,7 @@ Address LINK 'CSLULXSB'
  /********************************************************************/ 
  /* any parms are treated as an IMS operator command to issue.       */ 
  /********************************************************************/ 
-name='%s'
+name="%s"
 Parse upper var name theIMScmd '~' route                                     
                                                                         
  /********************************************************************/ 

--- a/plugins/module_utils/ims_module_error_messages.py
+++ b/plugins/module_utils/ims_module_error_messages.py
@@ -1,6 +1,6 @@
 class ErrorMessages():
     BATCH_FAILURE_MSG = "Failed. Check 'msg' field in 'ims_output' for more details."
-    INVALID_COMMAND_MSG = "Malformed Command."
+    INVALID_CHAR_IN_CMD = "Invalid character(s) found in command."
     INVALID_PLEX_MSG = "Malformed Plex."
     INVALID_ROUTE_MSG = "One or more routes specified are malformed."
     JSON_DECODE_ERROR_MSG = "Unable to decode string into JSON."
@@ -9,6 +9,7 @@ class ErrorMessages():
     NO_OUTPUT_MSG = "No job output was found."
     NO_RC_MSG = "Error verifying return code."
     NON_ZERO_RC_MSG = "Non-zero return code returned."
+    NON_ZERO_ERR_MSG = "Refer to IMS return codes."
     REXX_RETURN_CODE_MSG = "The following REXX error code was returned: "
     SUBMISSION_ERROR_MSG = "Error submitting IMS Command."
     SUCCESS_MSG = "Success"

--- a/plugins/modules/ims_command.py
+++ b/plugins/modules/ims_command.py
@@ -221,6 +221,7 @@ def format_ims_command(raw_command):
       return is_valid, error_msg, None
 
     command = raw_command.strip()
+    command = command.replace("\"", "\'")
     return is_valid, None, command
 
 def format_plex(raw_plex):

--- a/plugins/modules/ims_command.py
+++ b/plugins/modules/ims_command.py
@@ -484,12 +484,13 @@ def run_module():
         result['ims_output'].append(command_result_dict)
         if not status:
             module.fail_json(**result)
+        else:
+            result['changed'] = True
 
     if failure_occured:
         result['msg'] = em.BATCH_FAILURE_MSG
         module.fail_json(**result)
 
-    # result['changed'] = True # TODO: Determine when the target state will "change". After command is submitted?
     result['msg'] = em.SUCCESS_MSG
     module.exit_json(**result)
 

--- a/plugins/modules/ims_command.py
+++ b/plugins/modules/ims_command.py
@@ -221,7 +221,7 @@ def format_ims_command(raw_command):
       return is_valid, error_msg, None
 
     command = raw_command.strip()
-    command = command.replace("\"", "\'")
+    command = command.replace('\"', '\"\"')
     return is_valid, None, command
 
 def format_plex(raw_plex):

--- a/plugins/modules/ims_command.py
+++ b/plugins/modules/ims_command.py
@@ -204,7 +204,7 @@ from ansible_collections.ibm.ibm_zos_ims.plugins.module_utils.ims_module_error_m
 # from traceback import format_exc
 
 def format_ims_command(raw_command):
-    """Cleans and verifies the user input for IMS Command is valid.
+    """Cleans and verifies the user entered an IMS Command.
 
     Arguments:
         raw_command {str} -- Raw user input for `command` parameter.
@@ -214,21 +214,13 @@ def format_ims_command(raw_command):
         {str} -- Error message, or None for valid command.
         {str} -- Verified IMS Command.
     """
+    is_valid = True
     if not raw_command:
       is_valid = False
       error_msg = em.MISSING_COMMAND
       return is_valid, error_msg, None
 
     command = raw_command.strip()
-    pattern = r"[a-z0-9\(\)\*\s,?]+$"
-    match = re.match(pattern, command, flags=re.IGNORECASE)
-
-    if not match:
-        is_valid = False
-        error_msg = em.INVALID_COMMAND_MSG
-        return is_valid, error_msg, None
-
-    is_valid = True
     return is_valid, None, command
 
 def format_plex(raw_plex):
@@ -371,6 +363,8 @@ def scan_for_rexx_error(rexx_output):
         match = re.search(pattern, rexx_output, flags=re.IGNORECASE)
         if match:
             return em.REXX_RETURN_CODE_MSG + match.group(1)
+        elif "invalid character" in rexx_output.lower():
+            return em.INVALID_CHAR_IN_CMD
 
 
 def execute_ims_command(command, plex, route, module):
@@ -405,12 +399,17 @@ def execute_ims_command(command, plex, route, module):
         json_output = json.loads(out, strict=False)
     except ValueError:
         result['msg'] = em.JSON_DECODE_ERROR_MSG
-        result['err'] = scan_for_rexx_error(out)
+        rexx_error = scan_for_rexx_error(out)
+        if rexx_error:
+          result['err'] = rexx_error
+        else:
+          result['err'] = err
         return False, result
 
     is_valid, err = verify_return_code(json_output)
     if not is_valid:
         json_output['msg'] = err
+        json_output['err'] = em.NON_ZERO_ERR_MSG
         return False, json_output
     if rc == None:
         json_output['msg'] = err

--- a/tests/functional/modules/ims_command/invalid_input/test_invalid_command.py
+++ b/tests/functional/modules/ims_command/invalid_input/test_invalid_command.py
@@ -31,7 +31,10 @@ def test_invalid_command_characters(ansible_zos_module, command, plex, route):
     hosts = ansible_zos_module
     response = hosts.all.ims_command(command=command, plex=plex, route=route)
     for result in response.contacted.values():
-        assert result['ims_output'][0]['msg'] == em.INVALID_COMMAND_MSG
+        pprint(result)
+        msg = result['ims_output'][0]['msg']
+        err = result['ims_output'][0]['err']
+        assert (msg == em.NON_ZERO_RC_MSG) or (err == em.INVALID_CHAR_IN_CMD)
 
 def test_malformed_command(ansible_zos_module):
     hosts = ansible_zos_module

--- a/tests/functional/modules/ims_command/misc_commands/test_special_characters.py
+++ b/tests/functional/modules/ims_command/misc_commands/test_special_characters.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+from pprint import pprint
+import pytest
+
+__metaclass__ = type
+
+SUCCESSFUL_RC = '00000000'
+SUCCESSFUL_CC = '0'
+PLEX = "PLEX1"
+ROUTE = "IMS1"
+
+# Test single quotation functions properly
+def test_command_with_single_quotes(ansible_zos_module):
+    hosts = ansible_zos_module
+    results = hosts.all.ims_command(command="RML DBRC='RECON STATUS'", plex=PLEX, route=ROUTE)
+    for result in results.contacted.values():
+        pprint(result)
+        assert result['changed'] == True
+        assert result['msg'] == "Success"
+
+# Test double quotation functions properly
+def test_command_with_double_quotes(ansible_zos_module):
+    hosts = ansible_zos_module
+    results = hosts.all.ims_command(command='QUEUE TRAN NAME(TRAN1) OPTION(ENQ) DATA(some"data")', plex=PLEX, route=ROUTE)
+    for result in results.contacted.values():
+        pprint(result)
+        # Failure to parse results in the command being interpreted as a type 1 command
+        assert result['ims_output'][0]['type_2_response']
+
+def test_incomplete_command_with_double_quotes(ansible_zos_module):
+    hosts = ansible_zos_module
+    results = hosts.all.ims_command(command='QUEUE TRAN NAME(TRAN1) OPTION(ENQ) DATA(some"data', plex=PLEX, route=ROUTE)
+    for result in results.contacted.values():
+        pprint(result)
+        assert result['ims_output'][0]['type_1_response']
+        assert result['changed'] == False

--- a/tests/units/modules/ims_command/test_ims_command.py
+++ b/tests/units/modules/ims_command/test_ims_command.py
@@ -47,9 +47,7 @@ test_data_ims_command_structure = [
     ("query pgm show(all)", True, None),
     ("Not A Real IMS Command)", True, None),
     ("QUERY PGM AA?AA)", True, None),
-    ('inv@lid character', False, ims_em.INVALID_COMMAND_MSG),
-    ('mor3 inval!d character$', False, ims_em.INVALID_COMMAND_MSG),
-    ('unpaired " quote', False, ims_em.INVALID_COMMAND_MSG)
+    ('', False, ims_em.MISSING_COMMAND)
 
 ]
 @pytest.mark.parametrize("raw_command, expected_flag, expected_msg", test_data_ims_command_structure)

--- a/tests/units/modules/ims_command/test_ims_command.py
+++ b/tests/units/modules/ims_command/test_ims_command.py
@@ -47,7 +47,7 @@ test_data_ims_command_structure = [
     ("query pgm show(all)", True, None),
     ("Not A Real IMS Command)", True, None),
     ("QUERY PGM AA?AA)", True, None),
-    ('', False, ims_em.MISSING_COMMAND)
+    ('', False, ims_em.MISSING_COMMAND) 
 
 ]
 @pytest.mark.parametrize("raw_command, expected_flag, expected_msg", test_data_ims_command_structure)


### PR DESCRIPTION
##### SUMMARY
Removed the check for special characters in the IMS command input such as single quotes, double quotes, equals sign, etc. Updated associated unit and functional tests.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ims_command

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
[Nazare-2058](https://jsw.ibm.com/browse/NAZARE-2058)
