### PR TITLE
fix zoau_home undefined error. match all.yml config with core's config

### DIFF
--- a/playbooks/group_vars/all.yml
+++ b/playbooks/group_vars/all.yml
@@ -56,42 +56,11 @@ ZOAU: "/usr/lpp/IBM/zoautil"
 environment_vars:
   _BPXK_AUTOCVT: "ON"
   ZOAU_HOME: "{{ ZOAU }}"
-  PYTHONPATH: "{{ ZOAU_HOME }}/lib"
-  LIBPATH: "{{ ZOAU_HOME }}/lib:{{ PYZ }}/lib:/lib:/usr/lib:."
-  PATH: "{{ ZOAU_HOME }}/bin:{{ PYZ }}/bin:/bin:/var/bin:/usr/lpp/java/J8.0/bin"
+  PYTHONPATH: "{{ ZOAU }}/lib"
+  LIBPATH: "{{ ZOAU }}/lib:{{ PYZ }}/lib:/lib:/usr/lib:."
+  PATH: "{{ ZOAU }}/bin:{{ PYZ }}/bin:/bin:/var/bin:/usr/lpp/java/J8.0/bin"
   _CEE_RUNOPTS: "FILETAG(AUTOCVT,AUTOTAG) POSIX(ON)"
   _TAG_REDIR_ERR: "txt"
   _TAG_REDIR_IN: "txt"
   _TAG_REDIR_OUT: "txt"
   LANG: "C"
-  #####################
-  _BPXK_JOBLOG: STDERR
-  STEPLIB: IMSBLD.I15RTSMM.COMRESL1 # IMSNEW.DIPTI.IM00.SDFSRESL
-
-JOB_CARD: |-
-  //ANSIBLE JOB 'testing',
-  //  CLASS=H,MSGLEVEL=(1,1),REGION=0M,
-  //  MSGCLASS=H,NOTIFY=&SYSUID
-
-## environment_vars:
-##     LIBPATH: '/usr/lpp/izoda/v110/anaconda/lib:/u/omvsadm/mvsutil/lib:/lib:/usr/lib:.'
-##     ZOAU_ROOT: '/usr/lpp/zoautil/v100'
-##     ZOAUTIL_DIR: '/usr/lpp/zoautil/v100'
-##     PYTHONPATH: '/usr/lpp/izoda/v110/anaconda/lib:/u/omvsadm/mvsutil/lib:/lib:/usr/lib'
-##     PYTHON_HOME: '/usr/lpp/izoda/v110/anaconda'
-##     _BPXK_JOBLOG: STDERR
-##     # environment variables for mvsutils/mvscmd
-##     _BPXK_AUTOCVT: ON
-##     #_CEE_RUNOPTS: '"FILETAG(AUTOCVT,AUTOTAG) POSIX(ON)"'
-##     _TAG_REDIR_ERR: txt
-##     _TAG_REDIR_IN: txt
-##     _TAG_REDIR_OUT: txt
-##     TOOLS_ROOT: '/usr/lpp/rsusr/ported'
-##     PATH: '/u/omvsadm/mvsutil/bin:/usr/lpp/rsusr/ported/bin:/usr/lpp/java/java180/J8.0_64/bin:/bin:/var/bin:/usr/lpp/java/J8.0/bin:/usr/lpp/izoda/v110/anaconda/bin'
-##     JAVA_HOME: /usr/lpp/java/java180/J8.0_64
-##     STEPLIB: IMSBLD.I15RTSMM.COMRESL1 # IMSNEW.DIPTI.IM00.SDFSRESL
-##
-## JOB_CARD: |-
-##   //ANSIBLE JOB 'testing',
-##   //  CLASS=H,MSGLEVEL=(1,1),REGION=0M,
-##   //  MSGCLASS=H,NOTIFY=&SYSUID

--- a/playbooks/group_vars/all.yml
+++ b/playbooks/group_vars/all.yml
@@ -64,3 +64,12 @@ environment_vars:
   _TAG_REDIR_IN: "txt"
   _TAG_REDIR_OUT: "txt"
   LANG: "C"
+  #####################
+  _BPXK_JOBLOG: STDERR
+  STEPLIB: IMSBLD.I15RTSMM.COMRESL1 # IMSNEW.DIPTI.IM00.SDFSRESL
+
+JOB_CARD: |-
+  //ANSIBLE JOB 'testing',
+  //  CLASS=H,MSGLEVEL=(1,1),REGION=0M,
+  //  MSGCLASS=H,NOTIFY=&SYSUID
+


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fix zoau_home undefined error. match all.yml config with core's config. The Yaml interpreter seems unable to resolve variables at the environment_vars level if that's where they are also defined, case in point zoau_home. The error raised is:
The field 'environment' has an invalid value, which includes an undefined variable. The error was: 'ZOAU_HOME' is undefined
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
