### PR TITLE
Release v1.1.0-beta.1

### DIFF
--- a/docs/source/modules/ims_acb_gen.rst
+++ b/docs/source/modules/ims_acb_gen.rst
@@ -12,7 +12,7 @@ ims_acb_gen -- Generate IMS ACB
 .. contents::
    :local:
    :depth: 1
-
+   
 
 Synopsis
 --------
@@ -28,6 +28,7 @@ Parameters
 ----------
 
 
+ 
      
 acb_lib
   The ACB Maintenance utility maintains the prebuilt blocks (ACB) library (IMS.ACBLIB). The ACB library is a consolidated library of program (PSB) and database (DBD) descriptions.
@@ -39,6 +40,7 @@ acb_lib
   | **type**: str
 
 
+ 
      
 build_psb
   Specifies whether ims_acb_gen rebuilds all PSBs that reference a changed DBD in the *dbdname* parameter.
@@ -53,6 +55,7 @@ build_psb
   | **default**: True
 
 
+ 
      
 command_input
   This field specifies two command options(BUILD/DELETE).
@@ -67,6 +70,7 @@ command_input
   | **choices**: BUILD, DELETE
 
 
+ 
      
 compression
   PRECOMP,POSTCOMP, in any combination, cause the required in-place compression.
@@ -79,6 +83,7 @@ compression
   | **default**: none
 
 
+ 
      
 dbd_lib
   The ACB Maintenance utility receives input from the IMS DBDLIB data set.
@@ -90,6 +95,7 @@ dbd_lib
   | **type**: list
 
 
+ 
      
 dbd_name
   The name of the DBD(s). Specifies that blocks are built or deleted for this DBD, and for all PSBs that reference this DBD either directly or indirectly through logical relationships.
@@ -99,6 +105,7 @@ dbd_name
   | **type**: list
 
 
+ 
      
 psb_lib
   The ACB Maintenance utility receives input from the IMS PSBLIB data set.
@@ -112,6 +119,7 @@ psb_lib
   | **type**: list
 
 
+ 
      
 psb_name
   The name of the PS**s**. Specifies that blocks are built or deleted for all PSBs that are named on this control statement.
@@ -123,6 +131,7 @@ psb_name
   | **type**: list
 
 
+ 
      
 reslib
   Points to an authorized library that contains the IMS SVC modules. For IMS batch, SDFSRESL and any data set that is concatenated to it in the reslib field must be authorized through the Authorized Program Facility (APF).
@@ -132,6 +141,7 @@ reslib
   | **type**: list
 
 
+ 
      
 steplib
   Points to the IMS SDFSRESL data set, which contains the IMS nucleus and required IMS modules. If STEPLIB is unauthorized by having unauthorized libraries that are concatenated to SDFSRESL, you must specify the *reslib* parameter.
@@ -233,51 +243,65 @@ Notes
 Return Values
 -------------
 
-
-   
-                              
-       msg
-        | Execution result message from the ims_acb_gen module.
       
-        | **returned**: always
-        | **type**: str
-        | **sample**: ACBGEN execution is successful.
+                              
+         msg
+            | Execution result message from the ims_acb_gen module.
+            
+            | **returned**: always
+            
+            | **type**: str
 
+                  
+            | **sample**: ACBGEN execution is successful.
+      
             
       
-      
+         
                               
-       content
-        | The response from the execution of the ACB Maintenance Utility.
-      
-        | **returned**: always
-        | **type**: list
-      
-      
-                              
-       rc
-        | The resulting return code from the ACB Maintenance Utility.
-      
-        | **returned**: always
-        | **type**: str
-        | **sample**: 0
+         content
+            | The response from the execution of the ACB Maintenance Utility.
+            
+            | **returned**: always
+            
+            | **type**: list
 
+      
+      
+         
+                              
+         rc
+            | The resulting return code from the ACB Maintenance Utility.
+            
+            | **returned**: always
+            
+            | **type**: str
+
+                  
+            | **sample**: 0
+      
             
       
-      
+         
                               
-       changed
-        | Indicates if any changes were made during module execution.
+         changed
+            | Indicates if any changes were made during module execution.
+            
+            | **returned**: always
+            
+            | **type**: bool
+
       
-        | **returned**: always
-        | **type**: bool
       
-      
+         
                               
-       debug
-        | additional messages returned from ZOAU.
+         debug
+            | additional messages returned from ZOAU.
+            
+            | **returned**: always
+            
+            | **type**: str
+
       
-        | **returned**: always
-        | **type**: str
       
         

--- a/docs/source/modules/ims_catalog_populate.rst
+++ b/docs/source/modules/ims_catalog_populate.rst
@@ -1,0 +1,1467 @@
+
+:github_url: https://github.com/ansible-collections/ibm_zos_ims/blob/dev/plugins/modules/ims_catalog_populate.py
+
+.. _ims_catalog_populate_module:
+
+
+ims_catalog_populate -- Add records to the  IMS Catalog
+=======================================================
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+   
+
+Synopsis
+--------
+- The IMS Catalog Populate utility DFS3PU00 loads, inserts, or updates DBD and PSB instances into the database data sets of the IMS catalog from ACB library data sets.
+
+
+
+
+
+Parameters
+----------
+
+
+ 
+     
+acb_lib
+  Defines an ACB library data set that contains the ACB members that are used to populate the IMS catalog.
+
+
+  | **required**: True
+  | **type**: list
+
+
+ 
+     
+bootstrap_dataset
+  Optionally defines the IMS directory bootstrap data set.
+
+
+  | **required**: False
+  | **type**: dict
+
+
+ 
+     
+  abnormal_disposition
+    Data set action after abnormal termination
+
+
+    | **required**: False
+    | **type**: str
+    | **choices**: DELETE, KEEP, CATLG, UNCATLG
+
+
+ 
+     
+  block_size
+    The block size.
+
+
+    | **required**: False
+    | **type**: int
+
+
+ 
+     
+  data_class
+    The data class for an SMS-managed data set. Not valid for data sets that are not SMS-managed.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  dataset_name
+    Describes the name of the data set.
+
+
+    | **required**: True
+    | **type**: str
+
+
+ 
+     
+  disposition
+    The status of the data set.
+
+
+    | **required**: False
+    | **type**: str
+    | **choices**: NEW, OLD, SHR, EXCL
+
+
+ 
+     
+  management_class
+    The management class for an SMS-managed data set. Not valid for data sets that are not SMS-managed.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  normal_disposition
+    Data set action after normal termination.
+
+
+    | **required**: False
+    | **type**: str
+    | **choices**: DELETE, KEEP, CATLG, UNCATLG
+
+
+ 
+     
+  primary
+    The amount of primary space to allocate for the data set.
+
+
+    | **required**: False
+    | **type**: int
+
+
+ 
+     
+  primary_unit
+    The unit of size to use when specifying primary space.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  secondary
+    The amount of secondary space to allocate for the data set.
+
+
+    | **required**: False
+    | **type**: int
+
+
+ 
+     
+  secondary_unit
+    The unit of size to use when specifying secondary space.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  storage_class
+    The storage class for an SMS-managed data set. Not valid for data sets that are not SMS-managed.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  volumes
+    A list of volume serials. When providing multiple volumes, processing will begin with the first volume in the provided list. Offline volumes are not considered.
+
+
+    | **required**: False
+    | **type**: list
+
+
+
+ 
+     
+buffer_pool_param_dataset
+  Defines the buffer pool parameters data set. This option is required if you are running the utility as a DLI.
+
+
+  | **required**: False
+  | **type**: str
+
+
+ 
+     
+check_timestamp
+  Determines if the utility should check timestamps of ACB members with duplicate names.
+
+  If true, the utility will check if the ACB generation timestamp is different from the previously processed ACB member with the same name.
+
+  If the timestamp is different, it will use the ACB with the duplicate name. If not, it will ignore the ACB with the duplicate name.
+
+
+  | **required**: False
+  | **type**: bool
+
+
+ 
+     
+control_statements
+  The control statement parameters.
+
+
+  | **required**: False
+  | **type**: dict
+
+
+ 
+     
+  managed_acbs
+    Use the managed_acbs parameter to perform the following actions.
+
+    Set up IMS to manage the runtime application control blocks for your databases and program views.
+
+    Update an IMS system that manages ACBs with new or modified ACBs from an ACB library data set.
+
+    Save ACBs from an ACB library to a staging data set for later importing into an IMS system that manages ACBs.
+
+
+    | **required**: False
+    | **type**: dict
+
+
+ 
+     
+    setup
+      Creates the IMS directory data sets that are required by IMS to manage application control blocks.
+
+
+      | **required**: False
+      | **type**: bool
+
+
+ 
+     
+    stage
+      Saves ACBs from the input ACB libraries to a staging data set.
+
+
+      | **required**: False
+      | **type**: dict
+
+
+ 
+     
+      clean_staging_dataset
+        If the staging data set is not allocated to any online IMS system, scratch and recreate the staging data set before adding the resources to the staging data set.
+
+
+        | **required**: False
+        | **type**: bool
+
+
+ 
+     
+      gsamdbd
+        The name of the changed GSAM database. You can use the gsamdbd variable with the STAGE or UPDATE parameter.
+
+        LATEST, UNCOND, DELETE, SHARE, and GSAMPCB are not supported if you specify the gsamdbd variable.
+
+
+        | **required**: False
+        | **type**: str
+
+
+ 
+     
+      gsampcb
+        GSAM resources are included for MANAGEDACBS= running in DLI mode using PSB DFSCP001.
+
+        When GSAMPCB is specified, the IEFRDER batch log data set is not used by the catalog members information gather task.
+
+        GSAMPCB and clean_staging_dataset are mutually exclusive.
+
+
+        | **required**: False
+        | **type**: bool
+
+
+ 
+     
+      save_acb
+        If an ACB already exists in the IMS system, determines if it should be saved unconditionally or by the latest timestamp.
+
+
+        | **required**: False
+        | **type**: str
+        | **choices**: LATEST, UNCOND
+
+
+
+ 
+     
+    update
+      Updates the existing IMS directory system data sets directly in exclusive mode. The ACBs are not placed in the staging data set.
+
+
+      | **required**: False
+      | **type**: dic
+
+
+ 
+     
+      gsamdbd
+        The name of the changed GSAM database. You can use the gsamdbd variable with the STAGE or UPDATE parameter.
+
+        LATEST, UNCOND, DELETE, SHARE, and GSAMPCB are not supported if you specify the gsamdbd variable.
+
+
+        | **required**: False
+        | **type**: str
+
+
+ 
+     
+      gsampcb
+        GSAM resources are included for MANAGEDACBS= running in DLI mode using PSB DFSCP001. When GSAMPCB is specified, the IEFRDER batch log data set is not used by the catalog members information gather task.
+
+
+        | **required**: False
+        | **type**: bool
+
+
+ 
+     
+      replace_acb
+        If an ACB already exists in the IMS system, determines if it should be overwritten unconditionally or by the latest timestamp.
+
+
+        | **required**: False
+        | **type**: str
+        | **choices**: LATEST, UNCOND
+
+
+ 
+     
+      share_mode
+        For dynamic option (DOPT) PSBs only, allocates the required IMS directory data sets in a shared mode so that the DOPT PSBs can be added to the IMS catalog without interrupting online processing.
+
+
+        | **required**: False
+        | **type**: bool
+
+
+
+
+ 
+     
+  max_error_msgs
+    Terminate the IMS Catalog Populate utility when more than n messages indicate errors that prevent certain DBDs and PSBs from having their metadata that is written to the IMS catalog.
+
+    Equivalent to the ERRORMAX=n control statement.
+
+
+    | **required**: False
+    | **type**: int
+
+
+ 
+     
+  print_duplicate_resources
+    Specifies that the DFS3PU00 utility lists each DBD or PSB resource in the input ACB library that is not added to the IMS catalog because it is a duplicate of an instance in the IMS catalog.
+
+    Equivalent to the DUPLIST control statement.
+
+
+    | **required**: False
+    | **type**: bool
+
+
+ 
+     
+  print_inserted_resources
+    If the IMS management of ACBs is enabled, the utility also lists each DBD or PSB resources that is either added to the IMS directory or saved to the staging data set for importing into the IMS directory later.
+
+    Equivalent to the ISRTLIST control statement.
+
+
+    | **required**: False
+    | **type**: bool
+    | **default**: True
+
+
+ 
+     
+  resource_chkp_freq
+    Specifies the number of DBD and PSB resource instances to be inserted between checkpoints. n can be a 1 to 8 digit numeric value between 1 to 99999999.
+
+    Equivalent to the RESOURCE_CHKP_FREQ=n control statement.
+
+
+    | **required**: False
+    | **type**: int
+
+
+ 
+     
+  segment_chkp_freq
+    Specifies the number of segments to be inserted between checkpoints. Can be a 1 to 8 digit numeric value between 1 to 99999999.
+
+    Equivalent to the SEGMENT_CHKP_FREQ=n control statement.
+
+
+    | **required**: False
+    | **type**: int
+
+
+
+ 
+     
+dbd_lib
+  Defines the IMS.DBDLIB data sets.
+
+
+  | **required**: True
+  | **type**: list
+
+
+ 
+     
+dbrc
+  Indicates if the IMS Database Recovery Control facility is enabled.
+
+
+  | **required**: False
+  | **type**: bool
+
+
+ 
+     
+directory_datasets
+  Optionally defines the IMS directory data sets that are used to store the ACBs.
+
+  If this is omitted, the utility dynamically deletes any preexisting directory data sets and dynamically creates two new data sets to store the ACBs.
+
+  The data set name must conform to the same naming convention as for a system-created directory data set.
+
+
+  | **required**: False
+  | **type**: list
+
+
+ 
+     
+  abnormal_disposition
+    Data set action after abnormal termination.
+
+
+    | **required**: False
+    | **type**: str
+    | **choices**: DELETE, KEEP, CATLG, UNCATLG
+
+
+ 
+     
+  data_class
+    The data class for an SMS-managed data set. Not valid for data sets that are not SMS-managed.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  dataset_name
+    Describes the name of the data set.
+
+
+    | **required**: True
+    | **type**: str
+
+
+ 
+     
+  disposition
+    The status of the data set.
+
+
+    | **required**: False
+    | **type**: str
+    | **choices**: NEW, OLD, SHR, EXCL
+
+
+ 
+     
+  management_class
+    The management class for an SMS-managed data set. Not valid for data sets that are not SMS-managed.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  normal_disposition
+    Data set action after normal termination.
+
+
+    | **required**: False
+    | **type**: str
+    | **choices**: DELETE, KEEP, CATLG, UNCATLG
+
+
+ 
+     
+  primary
+    The amount of primary space to allocate for the data set.
+
+
+    | **required**: False
+    | **type**: int
+
+
+ 
+     
+  primary_unit
+    The unit of size to use when specifying primary space.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  secondary
+    The amount of secondary space to allocate for the data set.
+
+
+    | **required**: False
+    | **type**: int
+
+
+ 
+     
+  secondary_unit
+    The unit of size to use when specifying secondary space.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  storage_class
+    The storage class for an SMS-managed data set. Not valid for data sets that are not SMS-managed.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  volumes
+    A list of volume serials. When providing multiple volumes, processing will begin with the first volume in the provided list. Offline volumes are not considered.
+
+
+    | **required**: False
+    | **type**: list
+
+
+
+ 
+     
+directory_staging_dataset
+  Optionally defines the size and placement IMS of the directory staging data set.
+
+  The data set must follow the naming convention for the IMS Catalog Directory.
+
+
+  | **required**: False
+  | **type**: dict
+
+
+ 
+     
+  abnormal_disposition
+    Data set action after abnormal termination.
+
+
+    | **required**: False
+    | **type**: str
+    | **choices**: DELETE, KEEP, CATLG, UNCATLG
+
+
+ 
+     
+  data_class
+    The data class for an SMS-managed data set. Not valid for data sets that are not SMS-managed.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  dataset_name
+    Describes the name of the data set.
+
+
+    | **required**: True
+    | **type**: str
+
+
+ 
+     
+  disposition
+    The status of the data set.
+
+
+    | **required**: False
+    | **type**: str
+    | **choices**: NEW, OLD, SHR, EXCL
+
+
+ 
+     
+  management_class
+    The management class for an SMS-managed data set. Not valid for data sets that are not SMS-managed.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  normal_disposition
+    Data set action after normal termination.
+
+
+    | **required**: False
+    | **type**: str
+    | **choices**: DELETE, KEEP, CATLG, UNCATLG
+
+
+ 
+     
+  primary
+    The amount of primary space to allocate for the data set.
+
+
+    | **required**: False
+    | **type**: int
+
+
+ 
+     
+  primary_unit
+    The unit of size to use when specifying primary space.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  secondary
+    The amount of secondary space to allocate for the data set.
+
+
+    | **required**: False
+    | **type**: int
+
+
+ 
+     
+  secondary_unit
+    The unit of size to use when specifying secondary space.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  storage_class
+    The storage class for an SMS-managed data set. Not valid for data sets that are not SMS-managed.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  volumes
+    A list of volume serials. When providing multiple volumes, processing will begin with the first volume in the provided list. Offline volumes are not considered.
+
+
+    | **required**: False
+    | **type**: list
+
+
+
+ 
+     
+ims_id
+  The identifier of the IMS system on which the job is to be run.
+
+  Required if online_batch is true
+
+
+  | **required**: False
+  | **type**: str
+
+
+ 
+     
+irlm_id
+  The IRLM ID if IRLM is enabled. Cannot be specified when online_batch is true.
+
+
+  | **required**: False
+  | **type**: str
+
+
+ 
+     
+mode
+  Indicates the mode in which the Catalog Populate utility must be run.
+
+
+  | **required**: True
+  | **type**: str
+  | **choices**: LOAD, UPDATE, READ
+
+
+ 
+     
+modstat
+  Describes the IMS MODSTAT data set.
+
+
+  | **required**: False
+  | **type**: str
+
+
+ 
+     
+online_batch
+  Indicates if this utility is to be run in a BMP region.
+
+
+  | **required**: False
+  | **type**: bool
+
+
+ 
+     
+primary_log_dataset
+  Defines the primary IMS log data set. This is required if dbrc is set to true or if mode 'UPDATE' is selected.
+
+
+  | **required**: False
+  | **type**: dict
+
+
+ 
+     
+  abnormal_disposition
+    Data set action after abnormal termination.
+
+
+    | **required**: False
+    | **type**: str
+    | **choices**: DELETE, KEEP, CATLG, UNCATLG
+
+
+ 
+     
+  block_size
+    The block size.
+
+
+    | **required**: False
+    | **type**: int
+
+
+ 
+     
+  data_class
+    The data class for an SMS-managed data set. Not valid for data sets that are not SMS-managed.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  dataset_name
+    Describes the name of the data set.
+
+
+    | **required**: True
+    | **type**: str
+
+
+ 
+     
+  disposition
+    The status of the data set.
+
+
+    | **required**: False
+    | **type**: str
+    | **choices**: NEW, OLD, SHR, EXCL
+
+
+ 
+     
+  management_class
+    The management class for an SMS-managed data set. Not valid for data sets that are not SMS-managed.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  normal_disposition
+    Data set action after normal termination.
+
+
+    | **required**: False
+    | **type**: str
+    | **choices**: DELETE, KEEP, CATLG, UNCATLG
+
+
+ 
+     
+  primary
+    The amount of primary space to allocate for the data set.
+
+
+    | **required**: False
+    | **type**: int
+
+
+ 
+     
+  primary_unit
+    The unit of size to use when specifying primary space.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  record_format
+    The record format.
+
+
+    | **required**: False
+    | **type**: str
+    | **choices**: FB, VB, FBA, VBA, U
+
+
+ 
+     
+  record_length
+    The logical record length in bytes.
+
+
+    | **required**: False
+    | **type**: int
+
+
+ 
+     
+  secondary
+    The amount of secondary space to allocate for the data set.
+
+
+    | **required**: False
+    | **type**: int
+
+
+ 
+     
+  secondary_unit
+    The unit of size to use when specifying secondary space.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  storage_class
+    The storage class for an SMS-managed data set. Not valid for data sets that are not SMS-managed.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  type
+    The type of data set.
+
+
+    | **required**: False
+    | **type**: str
+    | **choices**: SEQ, BASIC, LARGE, PDS, PDSE, LIBRARY, LDS, RRDS, ESDS, KSDS
+
+
+ 
+     
+  volumes
+    A list of volume serials. When providing multiple volumes, processing will begin with the first volume in the provided list. Offline volumes are not considered.
+
+
+    | **required**: False
+    | **type**: list
+
+
+
+ 
+     
+proclib
+  Defines the IMS.PROCLIB data set that contains the DFSDFxxx member. The  DFSDFxxx member defines various attributes of the IMS catalog that are required by the utility.
+
+
+  | **required**: True
+  | **type**: list
+
+
+ 
+     
+psb_lib
+  Defines the IMS.PSBLIB data set.
+
+
+  | **required**: True
+  | **type**: list
+
+
+ 
+     
+reslib
+  Points to an authorized library that contains the IMS SVC modules.
+
+
+  | **required**: False
+  | **type**: list
+
+
+ 
+     
+secondary_log_dataset
+  Defines the secondary IMS log data set.
+
+
+  | **required**: False
+  | **type**: dict
+
+
+ 
+     
+  abnormal_disposition
+    Data set action after abnormal termination
+
+
+    | **required**: False
+    | **type**: str
+    | **choices**: DELETE, KEEP, CATLG, UNCATLG, CATALOG, UNCATALOG
+
+
+ 
+     
+  block_size
+    The block size.
+
+
+    | **required**: False
+    | **type**: int
+
+
+ 
+     
+  data_class
+    The data class for an SMS-managed data set. Not valid for data sets that are not SMS-managed.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  dataset_name
+    Describes the name of the data set.
+
+
+    | **required**: True
+    | **type**: str
+
+
+ 
+     
+  disposition
+    The status of the data set.
+
+
+    | **required**: False
+    | **type**: str
+    | **choices**: NEW, OLD, SHR, EXCL
+
+
+ 
+     
+  management_class
+    The management class for an SMS-managed data set. Not valid for data sets that are not SMS-managed.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  normal_disposition
+    Data set action after normal termination.
+
+
+    | **required**: False
+    | **type**: str
+    | **choices**: DELETE, KEEP, CATLG, UNCATLG, CATALOG, UNCATALOG
+
+
+ 
+     
+  primary
+    The amount of primary space to allocate for the data set.
+
+
+    | **required**: False
+    | **type**: int
+
+
+ 
+     
+  primary_unit
+    The unit of size to use when specifying primary space.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  record_format
+    The record format.
+
+
+    | **required**: False
+    | **type**: str
+    | **choices**: FB, VB, FBA, VBA, U
+
+
+ 
+     
+  record_length
+    The logical record length in bytes.
+
+
+    | **required**: False
+    | **type**: int
+
+
+ 
+     
+  secondary
+    The amount of secondary space to allocate for the data set.
+
+
+    | **required**: False
+    | **type**: int
+
+
+ 
+     
+  secondary_unit
+    The unit of size to use when specifying secondary space.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  storage_class
+    The storage class for an SMS-managed data set. Not valid for data sets that are not SMS-managed.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  type
+    The type of data set.
+
+
+    | **required**: False
+    | **type**: str
+    | **choices**: SEQ, BASIC, LARGE, PDS, PDSE, LIBRARY, LDS, RRDS, ESDS, KSDS
+
+
+ 
+     
+  volumes
+    A list of volume serials. When providing multiple volumes, processing will begin with the first volume in the provided list. Offline volumes are not considered.
+
+
+    | **required**: False
+    | **type**: list
+
+
+
+ 
+     
+steplib
+  Points to IMS.SDFSRESL, which contains the IMS nucleus and required IMS modules.
+
+  The steplib parameter can also be specified in the target inventory's environment_vars.
+
+  The steplib input parameter to the module will take precedence over the value specified in the environment_vars.
+
+
+  | **required**: False
+  | **type**: list
+
+
+ 
+     
+sysabend
+  Defines the dump data set. This defaults to = \*
+
+
+  | **required**: False
+  | **type**: str
+
+
+ 
+     
+sysprint
+  Defines the output message data set This defaults to = \*
+
+
+  | **required**: False
+  | **type**: str
+
+
+ 
+     
+temp_acb_dataset
+  An optional control statement to define an empty work data set to be used as an IMS.ACBLIB data set for the IMS Catalog Populate utility.
+
+  If IMS Management of ACBs is not enabled, this statement is ommitted.
+
+  This data set does not need to conform to any IMS Catalog or system-defined naming convention.
+
+
+  | **required**: False
+  | **type**: dict
+
+
+ 
+     
+  abnormal_disposition
+    Data set action after abnormal termination.
+
+
+    | **required**: False
+    | **type**: str
+    | **choices**: DELETE, KEEP, CATLG, UNCATLG
+
+
+ 
+     
+  data_class
+    The data class for an SMS-managed data set. Not valid for data sets that are not SMS-managed.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  dataset_name
+    Describes the name of the data set.
+
+
+    | **required**: True
+    | **type**: str
+
+
+ 
+     
+  disposition
+    The status of the data set.
+
+
+    | **required**: False
+    | **type**: str
+    | **choices**: NEW, OLD, SHR, EXCL
+
+
+ 
+     
+  management_class
+    The management class for an SMS-managed data set. Not valid for data sets that are not SMS-managed.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  normal_disposition
+    Data set action after normal termination.
+
+
+    | **required**: False
+    | **type**: str
+    | **choices**: DELETE, KEEP, CATLG, UNCATLG
+
+
+ 
+     
+  primary
+    The amount of primary space to allocate for the data set.
+
+
+    | **required**: False
+    | **type**: int
+
+
+ 
+     
+  primary_unit
+    The unit of size to use when specifying primary space.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  secondary
+    The amount of secondary space to allocate for the data set.
+
+
+    | **required**: False
+    | **type**: int
+
+
+ 
+     
+  secondary_unit
+    The unit of size to use when specifying secondary space.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  storage_class
+    The storage class for an SMS-managed data set. Not valid for data sets that are not SMS-managed.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  volumes
+    A list of volume serials. When providing multiple volumes, processing will begin with the first volume in the provided list. Offline volumes are not considered.
+
+
+    | **required**: False
+    | **type**: list
+
+
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+   
+   - name: Example of a loading the IMS Catalog running as a BMP
+     ims_catalog_populate:
+       online_batch: True
+       ims_id: IMS1
+       mode: LOAD
+       acb_lib: 
+         - SOME.IMS.ACBLIB
+       reslib: 
+         - SOME.IMS.SDFSRESL
+       steplib: 
+         - SOME.IMS.SDFSRESL
+       proclib: 
+         - SOME.IMS.PROCLIB
+       dbd_lib: 
+         - SOME.IMS.DBDLIB
+       psb_lib: 
+         - SOME.IMS.PSBLIB
+       buffer_pool_param_dataset: "SOME.IMS.PROCLIB(DFSVSMHP)"
+       primary_log_dataset:
+         dataset_name: SOME.IMS.LOG
+
+   - name: Example of loading the IMS Catalog and the IMS Directory data sets with MANAGEDACBS enabled
+     ims_catalog_populate:  
+       mode: LOAD
+       acb_lib: 
+         - SOME.IMS.ACBLIB
+       reslib: 
+         - SOME.IMS.SDFSRESL
+       steplib: 
+         - SOME.IMS.SDFSRESL
+       proclib: 
+         - SOME.IMS.PROCLIB
+       dbd_lib: 
+         - SOME.IMS.DBDLIB
+       psb_lib: 
+         - SOME.IMS.PSBLIB
+       buffer_pool_param_dataset: "SOME.IMS.PROCLIB(DFSVSMHP)"
+       control_statements:
+         managed_acbs:
+           setup: true
+
+   - name: Example of updating the IMS Catalog and staging libraries into the IMS directory staging data set
+     mode: UPDATE
+       acb_lib: 
+         - SOME.IMS.ACBLIB
+       reslib: 
+         - SOME.IMS.SDFSRESL
+       steplib: 
+         - SOME.IMS.SDFSRESL
+       proclib: 
+         - SOME.IMS.PROCLIB
+       dbd_lib: 
+         - SOME.IMS.DBDLIB
+       psb_lib: 
+         - SOME.IMS.PSBLIB
+       buffer_pool_param_dataset: "SOME.IMS.PROCLIB(DFSVSMHP)"
+       primary_log_dataset:
+         dataset_name: SOME.IMS.LOG
+       control_statements:
+         managed_acbs:
+           stage:
+             save_acb: UNCOND
+             clean_staging_dataset: true
+
+
+
+
+Notes
+-----
+
+.. note::
+   The *steplib* parameter can also be specified in the target inventory's environment_vars.
+
+   The *steplib* input parameter to the module will take precedence over the value specified in the environment_vars.
+
+   If only the *steplib* parameter is specified, then only the *steplib* concatenation will be used to resolve the IMS RESLIB data set.
+
+   Specifying only *reslib* without *steplib* is not supported.
+
+
+
+
+
+
+Return Values
+-------------
+
+      
+                              
+         content
+            | The standard output returned running the IMS Catalog Populate module.
+            
+            | **returned**: sometimes
+            
+            | **type**: str
+
+                  
+            | **sample**: DFS4434I INSTANCE 2020200562326 OF DBD AUTODB   WAS ADDED TO A NEWLY CREATED RECORD IN THE IMS CATALOG.
+      
+            
+      
+         
+                              
+         rc
+            | The return code from the IMS Catalog Populate utility.
+            
+            | **returned**: sometimes
+            
+            | **type**: str
+
+                  
+            | **sample**: 1
+      
+            
+      
+         
+                              
+         stderr
+            | The standard error output returned from running the IMS Catalog Populate utility.
+            
+            | **returned**: sometimes
+            
+            | **type**: str
+
+      
+      
+         
+                              
+         msg
+            | Messages returned from the IMS Catalog Populate module.
+            
+            | **returned**: sometimes
+            
+            | **type**: str
+
+                  
+            | **sample**: You cannot define directory data sets, the bootstrap data set, or directory staging data sets with MANAGEDACBS=STAGE or MANAGEDACBS=UPDATE
+      
+            
+      
+        

--- a/docs/source/modules/ims_catalog_purge.rst
+++ b/docs/source/modules/ims_catalog_purge.rst
@@ -1,0 +1,799 @@
+
+:github_url: https://github.com/ansible-collections/ibm_zos_ims/blob/dev/plugins/modules/ims_catalog_purge.py
+
+.. _ims_catalog_purge_module:
+
+
+ims_catalog_purge -- Purge records from the IMS Catalog
+=======================================================
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+   
+
+Synopsis
+--------
+- The IMS Catalog Purge  utility DFS3PU10 removes the segments that represent a DBD or PSB instance, all instances of a DBD version, or an entire DBD or PSB record from the IMS catalog. You can also analyze the catalog and generate delete statements for ACBs eligible for deletion, as well as update the ACB retention criteria.
+
+
+
+
+
+Parameters
+----------
+
+
+ 
+     
+buffer_pool_param_dataset
+  Defines the buffer pool parameters data set. This option is required if you are running the utility as a DLI.
+
+
+  | **required**: False
+  | **type**: str
+
+
+ 
+     
+dbd_lib
+  Defines the IMS.DBDLIB data sets.
+
+
+  | **required**: True
+  | **type**: list
+
+
+ 
+     
+dbrc
+  Indicates if the IMS Database Recovery Control facility is enabled.
+
+
+  | **required**: False
+  | **type**: bool
+
+
+ 
+     
+delete
+  Specifies a DBD or PSB instance or an entire DBD or PSB record to delete from the IMS catalog database.
+
+  This option must be used with PURGE mode and overrides any retention criteria, hence you can remove any DBD or PSB that would not otherwise be eligible for deletion.
+
+
+  | **required**: False
+  | **type**: list
+
+
+ 
+     
+  member_name
+    The 8 character IMS name of the DBD or PSB resource. Wildcards are supported.
+
+
+    | **required**: True
+    | **type**: str
+
+
+ 
+     
+  resource
+    Specify whether you want to delete a DBD or PSB.
+
+
+    | **required**: True
+    | **type**: str
+    | **choices**: DBD, PSB
+
+
+ 
+     
+  time_stamp
+    The ACB timestamp that identifies the specific DBD or PSB instance to purge.
+
+
+    | **required**: True
+    | **type**: int
+
+
+
+ 
+     
+delete_dbd_by_version
+  Delete DBD instances based on the specified name and version. If ANALYSIS mode is specified, it will generate DELETE DBD statements in the SYSUT1 data set along with any other delete statements based off the retention criteria. If PURGE or BOTH mode is specified, it will write the delete statements to the SYSUT1 data set and then execute them.
+
+
+  | **required**: False
+  | **type**: list
+
+
+ 
+     
+  member_name
+    The 8 character name of the DBD that you are deleting a version from.
+
+
+    | **required**: True
+    | **type**: str
+
+
+ 
+     
+  version_number
+    The version number of the DBD that you are deleting. The value must match the version number that is specified on the DBVER keyword in the DBD generation statement of the version that you are deleting.
+
+
+    | **required**: True
+    | **type**: int
+
+
+
+ 
+     
+ims_id
+  The identifier of the IMS system on which the job is to be run.
+
+  Required if online_batch is true.
+
+
+  | **required**: False
+  | **type**: str
+
+
+ 
+     
+irlm_id
+  The IRLM ID if IRLM is enabled. Cannot be specified when online_batch is true.
+
+
+  | **required**: False
+  | **type**: str
+
+
+ 
+     
+managed_acbs
+  Specifies whether deleting DBD and PSB instances from the IMS catalog causes the corresponding DBD and PSB instances in the IMS directory to be deleted. If 'analysis_mode' is true, the DBD and PSB instances will not be deleted from the IMS directory.
+
+
+  | **required**: False
+  | **type**: bool
+
+
+ 
+     
+mode
+  Determines which mode the utility runs in. ANALYSIS mode generates delete statements based on the retention criteria and places them in the SYSUT1 data set. PURGE mode executes delete statements in the SYSUT1 data set. BOTH mode performs ANALYSIS and PURGE mode consecutively.
+
+
+  | **required**: True
+  | **type**: str
+  | **choices**: PURGE, BOTH, ANALYSIS
+
+
+ 
+     
+online_batch
+  Indicates if this utility is to be run in a BMP region.
+
+
+  | **required**: False
+  | **type**: bool
+
+
+ 
+     
+primary_log_dataset
+  Defines the primary IMS log data set. This option is required if you are running the utility as a DLI.
+
+
+  | **required**: True
+  | **type**: dict
+
+
+ 
+     
+  abnormal_disposition
+    Data set action after abnormal termination.
+
+
+    | **required**: False
+    | **type**: str
+    | **choices**: DELETE, KEEP, CATLG, UNCATLG
+
+
+ 
+     
+  block_size
+    The block size.
+
+
+    | **required**: False
+    | **type**: int
+
+
+ 
+     
+  data_class
+    The data class for an SMS-managed data set. Not valid for data sets that are not SMS-managed.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  dataset_name
+    Describes the name of the data set.
+
+
+    | **required**: True
+    | **type**: str
+
+
+ 
+     
+  disposition
+    The status of the data set.
+
+
+    | **required**: False
+    | **type**: str
+    | **choices**: NEW, OLD, SHR, EXCL
+
+
+ 
+     
+  management_class
+    The management class for an SMS-managed data set. Not valid for data sets that are not SMS-managed.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  normal_disposition
+    Data set action after normal termination.
+
+
+    | **required**: False
+    | **type**: str
+    | **choices**: DELETE, KEEP, CATLG, UNCATLG
+
+
+ 
+     
+  primary
+    The amount of primary space to allocate for the data set.
+
+
+    | **required**: False
+    | **type**: int
+
+
+ 
+     
+  primary_unit
+    The unit of size to use when specifying primary space.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  record_format
+    The record format.
+
+
+    | **required**: False
+    | **type**: str
+    | **choices**: FB, VB, FBA, VBA, U
+
+
+ 
+     
+  record_length
+    The logical record length in bytes.
+
+
+    | **required**: False
+    | **type**: int
+
+
+ 
+     
+  secondary
+    The amount of secondary space to allocate for the data set.
+
+
+    | **required**: False
+    | **type**: int
+
+
+ 
+     
+  secondary_unit
+    The unit of size to use when specifying secondary space.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  storage_class
+    The storage class for an SMS-managed data set. Not valid for data sets that are not SMS-managed.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  type
+    The type of data set.
+
+
+    | **required**: False
+    | **type**: str
+    | **choices**: SEQ, BASIC, LARGE, PDS, PDSE, LIBRARY, LDS, RRDS, ESDS, KSDS
+
+
+ 
+     
+  volumes
+    A list of volume serials. When providing multiple volumes, processing will begin with the first volume in the provided list. Offline volumes are not considered.
+
+
+    | **required**: False
+    | **type**: list
+
+
+
+ 
+     
+proclib
+  Defines the IMS.PROCLIB data set that contains the DFSDFxxx member. The DFSDFxxx member defines various attributes of the IMS catalog that are required by the utility.
+
+
+  | **required**: True
+  | **type**: list
+
+
+ 
+     
+psb_lib
+  Defines the IMS.PSBLIB data set.
+
+
+  | **required**: True
+  | **type**: list
+
+
+ 
+     
+reslib
+  Points to an authorized library that contains the IMS SVC modules.
+
+
+  | **required**: False
+  | **type**: list
+
+
+ 
+     
+resource_chkp_freq
+  Specifies the number of resource instances to be deleted or updated between checkpoints. Can be a 1 to 8 digit numeric value between 1 to 99999999. The default value is 200.
+
+
+  | **required**: False
+  | **type**: int
+
+
+ 
+     
+steplib
+  Points to IMS.SDFSRESL, which contains the IMS nucleus and required IMS modules.
+
+  The steplib parameter can also be specified in the target inventory's environment_vars.
+
+  The steplib input parameter to the module will take precedence over the value specified in the environment_vars.
+
+
+  | **required**: False
+  | **type**: list
+
+
+ 
+     
+sysut1
+  The data set where delete statements are written to. Written either by the purge utility when specifying ANALYSIS or BOTH mode, or by the user when specifying PURGE mode.
+
+
+  | **required**: True
+  | **type**: dict
+
+
+ 
+     
+  abnormal_disposition
+    Data set action after abnormal termination.
+
+
+    | **required**: False
+    | **type**: str
+    | **choices**: DELETE, KEEP, CATLG, UNCATLG
+
+
+ 
+     
+  block_size
+    The block size.
+
+
+    | **required**: False
+    | **type**: int
+
+
+ 
+     
+  data_class
+    The data class for an SMS-managed data set. Not valid for data sets that are not SMS-managed.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  dataset_name
+    Describes the name of the data set.
+
+
+    | **required**: True
+    | **type**: str
+
+
+ 
+     
+  disposition
+    The status of the data set.
+
+
+    | **required**: False
+    | **type**: str
+    | **choices**: NEW, OLD, SHR, EXCL
+
+
+ 
+     
+  management_class
+    The management class for an SMS-managed data set. Not valid for data sets that are not SMS-managed.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  normal_disposition
+    Data set action after normal termination.
+
+
+    | **required**: False
+    | **type**: str
+    | **choices**: DELETE, KEEP, CATLG, UNCATLG
+
+
+ 
+     
+  primary
+    The amount of primary space to allocate for the data set.
+
+
+    | **required**: False
+    | **type**: int
+
+
+ 
+     
+  primary_unit
+    The unit of size to use when specifying primary space.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  secondary
+    The amount of secondary space to allocate for the data set.
+
+
+    | **required**: False
+    | **type**: int
+
+
+ 
+     
+  secondary_unit
+    The unit of size to use when specifying secondary space.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  storage_class
+    The storage class for an SMS-managed data set. Not valid for data sets that are not SMS-managed.
+
+
+    | **required**: False
+    | **type**: str
+
+
+ 
+     
+  type
+    The type of the data set.
+
+
+    | **required**: False
+    | **type**: str
+    | **choices**: SEQ, BASIC, LARGE, PDS, PDSE, LIBRARY, LDS, RRDS, ESDS, KSDS
+
+
+ 
+     
+  volumes
+    A list of volume serials. When providing multiple volumes, processing will begin with the first volume in the provided list. Offline volumes are not considered.
+
+
+    | **required**: False
+    | **type**: list
+
+
+
+ 
+     
+update_retention_criteria
+  Use this statement to set the retention criteria for DBD or PSB records in the catalog database. You can submit any number of update statements. You cannot specify this option if PURGE mode is selected. If used with any other mode options, it will update the retention criteria first.
+
+
+  | **required**: False
+  | **type**: list
+
+
+ 
+     
+  days
+    The number of days that an instance of a DBD or PSB must be retained before it can be purged.
+
+
+    | **required**: False
+    | **type**: int
+
+
+ 
+     
+  instances
+    The number of instances of a DBD or PSB that must be retained in the DBD or PSB record.
+
+
+    | **required**: True
+    | **type**: int
+
+
+ 
+     
+  member_name
+    The 8 character IMS name of the DBD or PSB resource. Wildcards are supported.
+
+
+    | **required**: True
+    | **type**: str
+
+
+ 
+     
+  resource
+    Specifies whether a DBD or PSB should be updated.
+
+
+    | **required**: True
+    | **type**: str
+    | **choices**: DBD, PSB
+
+
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+   
+   - name: Purge the IMS Catalog of DBDs beginning with 'DB'
+     ims_catalog_purge:
+       reslib: 
+         - SOME.IMS.SDFSRESL
+       steplib: 
+         - SOME.IMS.SDFSRESL
+       proclib: 
+         - SOME.IMS.PROCLIB 
+       dbd_lib: 
+         - SOME.IMS.DBDLIB
+       psb_lib: 
+         - SOME.IMS.PSBLIB
+       buffer_pool_param_dataset: "SOME.IMS1.PROCLIB(DFSVSMHP)"
+       primary_log_dataset:
+         dataset_name: SOME.IMS.LOG1
+       mode: PURGE
+       delete:
+         - resource: DBD
+           member_name: 'AUTODB'
+           time_stamp: 500
+
+   - name: Purge the IMS Catalog and the IMS Directory of DBDs beginning with 'DB'
+     ims_catalog_purge:
+       reslib: 
+         - SOME.IMS.SDFSRESL
+       steplib: 
+         - SOME.IMS.SDFSRESL
+       proclib: 
+         - SOME.IMS.PROCLIB 
+       dbd_lib: 
+         - SOME.IMS.DBDLIB
+       psb_lib: 
+         - SOME.IMS.PSBLIB
+       buffer_pool_param_dataset: "SOME.IMS1.PROCLIB(DFSVSMHP)"
+       primary_log_dataset:
+         dataset_name: SOME.IMS.LOG1
+       mode: PURGE
+       delete:
+         - resource: DBD
+           member_name: AUTODB
+           time_stamp: 500
+       managed_acbs: true
+
+   - name: Analyze the IMS Catalog and generate delete statements for resources eligible for deletion
+     ims_catalog_purge:
+       reslib: 
+         - SOME.IMS.SDFSRESL
+       steplib: 
+         - SOME.IMS.SDFSRESL
+       proclib: 
+         - SOME.IMS.PROCLIB 
+       dbd_lib: 
+         - SOME.IMS.DBDLIB
+       psb_lib: 
+         - SOME.IMS.PSBLIB
+       buffer_pool_param_dataset: "SOME.IMS1.PROCLIB(DFSVSMHP)"
+       primary_log_dataset:
+         dataset_name: SOME.IMS.LOG1
+       mode: ANALYSIS
+
+   - name: Update resource retention criteria for resources in the IMS Catalog while running as BMP
+     ims_catalog_purge:
+       online_batch: True
+       ims_id: IMS1
+       reslib: 
+         - SOME.IMS.SDFSRESL
+       steplib: 
+         - SOME.IMS.SDFSRESL
+       proclib: 
+         - SOME.IMS.PROCLIB 
+       dbd_lib: 
+         - SOME.IMS.DBDLIB
+       psb_lib: 
+         - SOME.IMS.PSBLIB
+       buffer_pool_param_dataset: "SOME.IMS1.PROCLIB(DFSVSMHP)"
+       primary_log_dataset:
+         dataset_name: SOME.IMS.LOG1
+       mode: ANALYSIS
+       update_retention_criteria:
+         - resource: DBD
+           member_name: AUTODB
+           instances: 0
+           days: 0
+         - resource: PSB
+           member_name: DBF000
+           instances: 0
+           days: 0
+
+
+
+
+Notes
+-----
+
+.. note::
+   The *steplib* parameter can also be specified in the target inventory's environment_vars.
+
+   The *steplib* input parameter to the module will take precedence over the value specified in the environment_vars.
+
+   If only the *steplib* parameter is specified, then only the *steplib* concatenation will be used to resolve the IMS RESLIB data set.
+
+   Specifying only *reslib* without *steplib* is not supported.
+
+
+
+
+
+
+Return Values
+-------------
+
+      
+                              
+         content
+            | The standard output returned running the IMS Catalog Purge utility.
+            
+            | **returned**: always
+            
+            | **type**: str
+
+                  
+            | **sample**: DFS4810I ALL OF THE MEMBER INSTANCES THAT ARE REFERENCED IN THE SYSUT1 DATA SET WERE DELETED FROM THE IMS CATALOG.
+      
+            
+      
+         
+                              
+         rc
+            | The return code from the IMS Catalog Purge utility.
+            
+            | **returned**: sometimes
+            
+            | **type**: str
+
+                  
+            | **sample**: 0
+      
+            
+      
+         
+                              
+         stderr
+            | The standard error output returned from running the IMS Catalog Purge utility.
+            
+            | **returned**: sometimes
+            
+            | **type**: str
+
+                  
+            | **sample**: 12.27.08 STC00143  +DFS671I OMVSADM8.STEP1. - FOR THIS EXECUTION, DBRC IS SET TO NO     IMS1
+      
+            
+      
+         
+                              
+         msg
+            | Messages returned from the IMS Catalog Purge module.
+            
+            | **returned**: sometimes
+            
+            | **type**: str
+
+                  
+            | **sample**: You must specify a buffer pool parameter data set when running as DLI.
+      
+            
+      
+        

--- a/docs/source/modules/ims_dbrc.rst
+++ b/docs/source/modules/ims_dbrc.rst
@@ -1,0 +1,319 @@
+
+:github_url: https://github.com/ansible-collections/ibm_zos_ims/blob/dev/plugins/modules/ims_dbrc.py
+
+.. _ims_dbrc_module:
+
+
+ims_dbrc -- Submit IMS DBRC Commands
+====================================
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+   
+
+Synopsis
+--------
+- Use Database Recovery Control (DBRC) to record and manage information that is stored in a set of VSAM data sets that are collectively called the Recovery Control (RECON) data set.
+- Based on this information, you can use DBRC to advise IMS about how to proceed with certain IMS actions.
+
+
+
+
+
+Parameters
+----------
+
+
+ 
+     
+command
+  This is the well-formatted DBRC command to submit.
+
+
+  | **required**: True
+  | **type**: list
+
+
+ 
+     
+dbd_lib
+  The data set that contains the descriptions for the databases that are under the control of DBRC.
+
+
+  | **required**: False
+  | **type**: str
+
+
+ 
+     
+dynamic_allocation_dataset
+  The dynamic allocation data set that will be used to complete the DBRC execution.
+
+  Required if `recon1`, `recon2`, and `recon3` are not specified.
+
+
+  | **required**: False
+  | **type**: str
+
+
+ 
+     
+genjcl_input_dataset
+  The PDS, which contains the skeletal JCL members used by the DBRC utility to generate JCL.
+
+  Equivalent to the JCLPDS control statement.
+
+
+  | **required**: False
+  | **type**: str
+
+
+ 
+     
+genjcl_output_dataset
+  The data set which is to receive the generated JCL. It is required only for the GENJCL commands.
+
+  Equivalent to the JCLOUT control statement.
+
+
+  | **required**: False
+  | **type**: str
+
+
+ 
+     
+max_rc
+  The maximum acceptable return code allowed for the module to complete succesfully.
+
+
+  | **required**: False
+  | **type**: int
+
+
+ 
+     
+recon1
+  The RECON1 data set that will be used to complete the DBRC execution.
+
+  Required if `dynamic_allocation_dataset` is not specified.
+
+
+  | **required**: False
+  | **type**: str
+
+
+ 
+     
+recon2
+  The RECON2 data set that will be used to complete the DBRC execution.
+
+  Required if `dynamic_allocation_dataset` is not specified.
+
+
+  | **required**: False
+  | **type**: str
+
+
+ 
+     
+recon3
+  The RECON3 data set that will be used to complete the DBRC execution.
+
+  Required if `dynamic_allocation_dataset` is not specified.
+
+
+  | **required**: False
+  | **type**: str
+
+
+ 
+     
+steplib
+  List of STEPLIB datasets that contain the IMS nucleus and the required action modules.
+
+
+  | **required**: True
+  | **type**: list
+
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+   
+   - name: Sample DBRC Single Command
+     ims_dbrc:
+       command: LIST.RECON STATUS
+       steplib:
+         - IMSTESTU.IMS1501.MARKER
+         - IMSTESTL.IMS1.EXITLIB
+         - IMSTESTG.IMS15R.TSTRES
+         - IMSBLD.IMS15R.USERLIB
+         - IMSBLD.I15RTSMM.CRESLIB
+       dbd_lib: IMSTESTL.IMS1.DBDLIB
+       genjcl_input_dataset: IMSTESTL.IMS1.GENJCL
+       genjcl_output_dataset: IMSTESTL.IMS1.JCLOUT
+       dynamic_allocation_dataset: IMSTESTL.IMS1.DYNALLOC
+
+   - name: Sample DBRC Multiple Commands with dynamic_allocation_dataset Specified
+     ims_dbrc:
+       command: 
+         - LIST.RECON STATUS
+         - LIST.DB ALL
+         - LIST.DBDS DBD(CUSTOMER)
+       steplib:
+         - IMSTESTU.IMS1501.MARKER
+         - IMSTESTL.IMS1.EXITLIB
+         - IMSTESTG.IMS15R.TSTRES
+         - IMSBLD.IMS15R.USERLIB
+         - IMSBLD.I15RTSMM.CRESLIB
+       dbd_lib: IMSTESTL.IMS1.DBDLIB
+       genjcl_input_dataset: IMSTESTL.IMS1.GENJCL
+       genjcl_output_dataset: IMSTESTL.IMS1.JCLOUT
+       dynamic_allocation_dataset: IMSTESTL.IMS1.SDFSRESL
+
+   - name: Sample DBRC Multiple Commands with RECON specified
+     ims_dbrc:
+       command: 
+         - LIST.RECON STATUS
+         - INIT.DB DBD(TESTDB)
+         - DELETE.DB DBD(TESTDB)
+       steplib:
+         - IMSTESTU.IMS1501.MARKER
+         - IMSTESTL.IMS1.EXITLIB
+         - IMSTESTG.IMS15R.TSTRES
+         - IMSBLD.IMS15R.USERLIB
+         - IMSBLD.I15RTSMM.CRESLIB
+       dbd_lib: IMSTESTL.IMS1.DBDLIB
+       genjcl_input_dataset: IMSTESTL.IMS1.GENJCL
+       genjcl_output_dataset: IMSTESTL.IMS1.JCLOUT
+       recon1: IMSTESTL.IMS1.RECON1
+       recon2: IMSTESTL.IMS1.RECON2
+       recon3: IMSTESTL.IMS1.RECON3
+
+
+
+
+Notes
+-----
+
+.. note::
+   The *steplib* parameter can also be specified in the target inventory's environment_vars.
+
+   The *steplib* input parameter to the module will take precedence over the value specified in the environment_vars.
+
+
+
+
+
+
+Return Values
+-------------
+
+      
+                              
+         changed
+            | Indicates if this module effectively modified the target state.
+            
+            | **returned**: always
+            
+            | **type**: boolean
+
+      
+      
+         
+                              
+         dbrc_output
+            | The output provided by the specified DBRC Command(s).
+            
+            | **returned**: sometimes
+            
+            | **type**: list[dict]
+
+      
+                    
+                              
+          command
+            | The original submitted command that corresponds to the output.
+            
+              | **returned**: always
+            
+              | **type**: str
+
+      
+      
+         
+                              
+          messages
+            | Compiled list of messages returned from the DBRC output.
+            
+              | **returned**: always
+            
+              | **type**: list
+
+      
+      
+         
+                              
+          output
+            | Parsed DBRC output that maps each field to its corresponding value.
+            
+              | **returned**: always
+            
+              | **type**: dict
+
+      
+      
+        
+      
+         
+                              
+         failed
+            | Indicates the outcome of the module.
+            
+            | **returned**: always
+            
+            | **type**: boolean
+
+      
+      
+         
+                              
+         msg
+            | The output message that the `ims_dbrc` module generates.
+            
+            | **returned**: always
+            
+            | **type**: str
+
+      
+      
+         
+                              
+         rc
+            | The return code returned by the DBRC module.
+            
+            | **returned**: always
+            
+            | **type**: int
+
+      
+      
+         
+                              
+         unformatted_output
+            | Unformatted output response from the all of the submitted DBRC commands.
+            
+            | **returned**: always
+            
+            | **type**: list
+
+      
+      
+        

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,8 +2,50 @@
 .. © Copyright IBM Corporation 2020                                          .
 .. ...........................................................................
 
+========
 Releases
 ========
+
+Version 1.1.0-beta.1
+====================
+
+Notes
+-----
+
+* Update recommended
+* New modules
+
+  * ``ims_catalog_populate``
+  * ``ims_catalog_purge``
+  * ``ims_dbrc``
+* Documentation 
+
+  * Update documentation in support of `centralized content`_.
+* Updated sample playbook
+
+Availability
+
+------------
+* `Galaxy`_
+* `GitHub`_
+
+Reference
+---------
+
+* Supported by IBM z/OS core collection v1.2.0-beta.1 or later
+* Supported by IBM Z Open Enterprise Python for z/OS: 3.8.2 or later
+* Supported by IBM Z Open Automation Utilities 1.0.3 PTF UI70435 or later
+* Supported by z/OS V2R3
+* The z/OS® shell
+
+.. _centralized content:
+   https://ibm.github.io/z_ansible_collections_doc/index.html
+
+.. _GitHub:
+   https://github.com/ansible-collections/ibm_zos_ims
+
+.. _Galaxy:
+   https://galaxy.ansible.com/ibm/ibm_zos_ims
 
 Version 1.0.0-beta3
 -------------------

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -24,8 +24,8 @@ Notes
 * Updated sample playbook
 
 Availability
-
 ------------
+
 * `Galaxy`_
 * `GitHub`_
 
@@ -48,7 +48,7 @@ Reference
    https://galaxy.ansible.com/ibm/ibm_zos_ims
 
 Version 1.0.0-beta3
--------------------
+====================
 
 Notes
   * Update recommended
@@ -72,7 +72,7 @@ Reference
   * The z/OS® shell
 
 Version 1.0.0-beta2
--------------------
+====================
 
 Notes
   * Update recommended
@@ -91,7 +91,7 @@ Reference
   * Supported by IBM z/OS core collection 1.0.0 or later
 
 Version 1.0.0-beta1
--------------------
+====================
 
 Notes
   * Initial beta release of IBM z/OS IMS collection, referred to as ibm_zos_ims

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -13,11 +13,13 @@ readme: README.md
 
 # Contributors
 authors:
+  - An Lam <an.lam@ibm.com>
   - Bryant Panyarachun <bpanyar@us.ibm.com>
   - Dipti Gandhi <ddgandhi@us.ibm.com>
   - Jerry Li <lij@us.ibm.com>
   - Ketan Kelkar <ketan.kelkar@ibm.com>
   - Omar Elbarmawi <omar@ibm.com>
+  - Radha Varadachari <radha.varadachari@ibm.com>
   - Seema Phalke <seema.s.phalke@ibm.com> 
 
 # Description

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -39,7 +39,7 @@ dependencies:
 repository: https://github.com/ansible-collections/ibm_zos_ims
 
 # The URL to any online docs
-documentation: https://ansible-collections.github.io/ibm_zos_ims/index.html
+documentation: https://ibm.github.io/z_ansible_collections_doc/index.html
 
 # The URL to the homepage of the collection/project
 homepage: https://www.ibm.com/support/z-content-solutions/ansible/

--- a/plugins/module_utils/dbrc.py
+++ b/plugins/module_utils/dbrc.py
@@ -9,7 +9,7 @@ from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.dd_statement impo
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.zos_mvs_raw import MVSCmd # pylint: disable=import-error
 from ansible_collections.ibm.ibm_zos_ims.plugins.module_utils.ims_module_error_messages import DBRCErrorMessages as em # pylint: disable=import-error
 
-class IMSDbrc():
+class dbrc():
     DBRC_UTILITY = "dspurx00"
     REPLACEMENT_VALUES = {
         "** NONE **": None,
@@ -165,8 +165,8 @@ class IMSDbrc():
                 fields[key] = None
             else:
                 value = value_list[0].strip()
-                if value in IMSDbrc.REPLACEMENT_VALUES:
-                    value = IMSDbrc.REPLACEMENT_VALUES[value]
+                if value in dbrc.REPLACEMENT_VALUES:
+                    value = dbrc.REPLACEMENT_VALUES[value]
                 fields[key] = value
             i += 1
             
@@ -300,7 +300,7 @@ class IMSDbrc():
         """
         try:
             dbrc_utility_fields = self._build_utility_statements()
-            response = MVSCmd.execute(IMSDbrc.DBRC_UTILITY, dbrc_utility_fields)
+            response = MVSCmd.execute(dbrc.DBRC_UTILITY, dbrc_utility_fields)
             fields, original_output, failure_detected = self._parse_output(response.stdout)
             # fields, original_output = self._parse_output(TEST_INPUT)
             res = {

--- a/plugins/modules/ims_dbrc.py
+++ b/plugins/modules/ims_dbrc.py
@@ -191,7 +191,7 @@ unformatted_output:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ibm.ibm_zos_ims.plugins.module_utils.IMSDbrc import IMSDbrc  # pylint: disable=import-error
+from ansible_collections.ibm.ibm_zos_ims.plugins.module_utils.dbrc import dbrc  # pylint: disable=import-error
 from ansible_collections.ibm.ibm_zos_ims.plugins.module_utils.ims_module_error_messages import DBRCErrorMessages as em # pylint: disable=import-error
 from ansible.module_utils.basic import AnsibleModule, env_fallback, AnsibleFallbackNotFound
 import re
@@ -249,7 +249,7 @@ def run_module():
   if environ_step_lib:
     combined_step_lib = module.params['steplib'] + environ_step_lib
   try:
-    response = IMSDbrc.IMSDbrc(
+    response = dbrc.dbrc(
       commands=module.params['command'],
       steplib=combined_step_lib,
       dbd_lib=module.params['dbd_lib'],

--- a/tests/units/modules/ims_dbrc/test_IMSDbrc.py
+++ b/tests/units/modules/ims_dbrc/test_IMSDbrc.py
@@ -6,7 +6,7 @@
 from __future__ import (absolute_import, division)
 __metaclass__ = type
 
-from ansible_collections.ibm.ibm_zos_ims.plugins.module_utils.IMSDbrc import IMSDbrc  # pylint: disable=import-error
+from ansible_collections.ibm.ibm_zos_ims.plugins.module_utils.dbrc import dbrc  # pylint: disable=import-error
 import pytest
 
 """
@@ -14,7 +14,7 @@ Spacing is important for the input values.
 Want to make sure different spacing scenarios 
 provide a consistent output.
 """
-test_data_IMSDbrc_extraction_values = [
+test_data_dbrc_extraction_values = [
     ('NUMBER OF REGISTERED DATABASES =        0', {'NUMBER OF REGISTERED DATABASES': '0'}),
     ('TIMEZIN = %SYS', {'TIMEZIN': '%SYS'}),
     ('COMMAND AUTH=NONE  HLQ=**NULL**  RCNQUAL=**NULL**', {'COMMAND AUTH': None, 'HLQ': None, "RCNQUAL": None}),
@@ -24,10 +24,10 @@ test_data_IMSDbrc_extraction_values = [
     ('RECOVERY NEEDED COUNT   =0', {'RECOVERY NEEDED COUNT': '0'}),
     ('RECOVERABLE           =YES         EEQE COUNT              =0', {'RECOVERABLE': True, 'EEQE COUNT': '0'})
 ]
-@pytest.mark.parametrize("line_input, expected_output_dict", test_data_IMSDbrc_extraction_values)
-def test_IMSDbrc_extract_values(zos_import_mocker, line_input, expected_output_dict):
+@pytest.mark.parametrize("line_input, expected_output_dict", test_data_dbrc_extraction_values)
+def test_dbrc_extract_values(zos_import_mocker, line_input, expected_output_dict):
     # mocker, importer = zos_import_mocker
-    imsdbrc = IMSDbrc("SAMPLE COMMAND", "SAMPLE STEPLIB", dynamic_allocation_dataset="SAMPLE DYNALLOC")
+    imsdbrc = dbrc("SAMPLE COMMAND", "SAMPLE STEPLIB", dynamic_allocation_dataset="SAMPLE DYNALLOC")
     actual_output = imsdbrc._extract_values(line_input)
     assert len(actual_output) == len(expected_output_dict)
     print(actual_output)


### PR DESCRIPTION
##### SUMMARY
release V1.1.0-beta.1

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### ADDITIONAL INFORMATION

Version 1.1.0-beta.1
====================

Notes
-----

* Update recommended
* New modules

  * ``ims_catalog_populate``
  * ``ims_catalog_purge``
  * ``ims_dbrc``
* Documentation 

  * Update documentation in support of `centralized content`_.
* Updated sample playbook

Availability
------------

* `Galaxy`_
* `GitHub`_

Reference
---------

* Supported by IBM z/OS core collection v1.2.0-beta.1 or later
* Supported by IBM Z Open Enterprise Python for z/OS: 3.8.2 or later
* Supported by IBM Z Open Automation Utilities 1.0.3 PTF UI70435 or later
* Supported by z/OS V2R3
* The z/OS® shell

