### PR TITLE
Ansible 2.10 and 2.11 Compatibility Issue

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -35,7 +35,7 @@ tags: [ibm, z, zos, z_os, core, zos_core, data_set, jcl, uss, mvs, ims, zos_ims]
 
 # Collections that this collection requires to be installed for it to be usable.
 dependencies:
-    "ibm.ibm_zos_core": ">=1.2.1"
+    "ibm.ibm_zos_core": ">=1.3.0"
 
 # The URL of the originating SCM repository
 repository: https://github.com/ansible-collections/ibm_zos_ims

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -35,7 +35,7 @@ tags: [ibm, z, zos, z_os, core, zos_core, data_set, jcl, uss, mvs, ims, zos_ims]
 
 # Collections that this collection requires to be installed for it to be usable.
 dependencies:
-    "ibm.ibm_zos_core": ">=1.3.0"
+    "ibm.ibm_zos_core": ">=1.2.1"
 
 # The URL of the originating SCM repository
 repository: https://github.com/ansible-collections/ibm_zos_ims

--- a/plugins/module_utils/acbgen.py
+++ b/plugins/module_utils/acbgen.py
@@ -130,8 +130,8 @@ class acbgen(object):
                 dbd_name_str = " " + self._split_lines_dbd()
                 commandList.append(dbd_name_str)
 
-        for a in commandList:
-            print(" commandList:  ", a)
+        # for a in commandList:
+        #     print(" commandList:  ", a)
         command_stdin_definitions = DDStatement(
             "SYSIN", StdinDefinition("\n".join(commandList)))
         acbgen_utility_fields.append(command_stdin_definitions)
@@ -299,7 +299,7 @@ class acbgen(object):
         self.result = {}
         response = None
         param_string = "UPB,"
-        print(" compression: ", self.compression)
+        # print(" compression: ", self.compression)
         if self.compression and self.compression.upper().startswith("PRECOMP"):
             response = self.compress()
             self.result = self.combine_results(response)

--- a/plugins/module_utils/dataset_utils.py
+++ b/plugins/module_utils/dataset_utils.py
@@ -58,11 +58,11 @@ def _write_data_set(name, contents):
         DatasetWriteError: When write to the data set fails.
     """
     # rc = Datasets.write(name, contents)
-    temp = tempfile.NamedTemporaryFile(delete=False)
-    with open(temp.name, "w") as f:
+    with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:
         f.write(contents)
+        temp_name = f.name
     rc, stdout, stderr = module.run_command(
-        "cp -O u {0} \"//'{1}'\"".format(temp.name, name)
+        "cp -O u {0} \"//'{1}'\"".format(temp_name, name)
     )
     if rc != 0:
         raise DatasetWriteError(name, rc, stderr)

--- a/plugins/module_utils/dbrc.py
+++ b/plugins/module_utils/dbrc.py
@@ -251,7 +251,7 @@ class dbrc():
                 elif re.search(success_pattern, line, re.IGNORECASE):
                     self._changed = True
         except Exception as e:
-            print(repr(e))
+            # print(repr(e))
             output_fields = {}
             failure_detected = True
         # finally:
@@ -320,7 +320,7 @@ class dbrc():
             }
 
         except Exception as e:
-            print("ERROR:", e)
+            # print("ERROR:", e)
             res = {
                 "dbrc_fields": [],
                 "original_output": [],

--- a/plugins/module_utils/ims_gen_utils.py
+++ b/plugins/module_utils/ims_gen_utils.py
@@ -95,7 +95,7 @@ def validate_member_list(member_list):
             if len(member) != 1:
                 return False, ims_em.INVALID_MEMBER_LIST_TYPE
 
-            src_member, target_name = [(k, v) for k, v in member.items()][0]
+            src_member, target_name = list(member.items())[0]
 
             # src_member must be a str and a valid member name
             if not isinstance(src_member, str):
@@ -336,7 +336,7 @@ def execute_gen_command(source, dest, syslib_list, run_command, module, result):
                         # else:
                         #     throw error
                         else:
-                            src_member, target_name = [(k, v) for k, v in item.items()][0]
+                            src_member, target_name = list(item.items())[0]
 
                         if src_member == '':
                             # result['ims_output'].append({

--- a/plugins/modules/ims_acb_gen.py
+++ b/plugins/modules/ims_acb_gen.py
@@ -286,7 +286,7 @@ def run_module():
             )
 
     try:
-        acbgen_obj = acbgen.acbgen(
+        acbgen_obj = acbgen(
             command_input,
             compression,
             psb_name,

--- a/plugins/modules/ims_acb_gen.py
+++ b/plugins/modules/ims_acb_gen.py
@@ -11,7 +11,7 @@ DOCUMENTATION = r'''
 ---
 module: ims_acb_gen
 short_description: Generate IMS ACB
-version_added: "2.9"
+version_added: "1.0.0"
 description:
   - The ims_acb_gen module generates an IMS application control block (ACB) necessary for an IMS application program to be scheduled and run.
   - The ims_dbd_gen and ims_psb_gen modules can be used to generate the associated IMS database descriptors (DBDs) and program specification
@@ -29,6 +29,8 @@ options:
     required: true
     type: str
     choices:
+      - build
+      - delete
       - BUILD
       - DELETE
   compression:
@@ -37,18 +39,27 @@ options:
       - The default is none.
     type: str
     required: false
+    choices:
+      - precomp
+      - postcomp
+      - precomp,postcomp
+      - PRECOMP
+      - POSTCOMP
+      - PRECOMP,POSTCOMP
   psb_name:
     description:
       - The name of the PSB(s). Specifies that blocks are built or deleted for all PSBs that are named on this control statement.
       - This field requires "ALL" or a list of psb names to be specified.
     required: false
     type: list
+    elements: str
   dbd_name:
     description:
       - The name of the DBD(s). Specifies that blocks are built or deleted for this DBD, and for all PSBs that reference this DBD
         either directly or indirectly through logical relationships.
     required: false
     type: list
+    elements: str
   acb_lib:
     description:
       - The ACB Maintenance utility maintains the prebuilt blocks (ACB) library (IMS.ACBLIB). The ACB library is a consolidated
@@ -66,6 +77,7 @@ options:
         name changed, all PSBs which are sensitive to that segment must have their SENSEG statements changed.
     required: true
     type: list
+    elements: str
   dbd_lib:
     description:
       - The ACB Maintenance utility receives input from the IMS DBDLIB data set.
@@ -73,6 +85,7 @@ options:
         in the associated DBD, make these changes before running the module.
     required: true
     type: list
+    elements: str
   steplib:
     description:
       - Points to the IMS SDFSRESL data set, which contains the IMS nucleus and required IMS modules. If STEPLIB is unauthorized by
@@ -81,12 +94,14 @@ options:
       - The steplib input parameter to the module will take precedence over the value specified in the environment_vars.
     required: false
     type: list
+    elements: str
   reslib:
     description:
       - Points to an authorized library that contains the IMS SVC modules. For IMS batch, SDFSRESL and any data set that is concatenated
         to it in the reslib field must be authorized through the Authorized Program Facility (APF).
     required: false
     type: list
+    elements: str
   build_psb:
     description:
       - Specifies whether ims_acb_gen rebuilds all PSBs that reference a changed DBD in the I(dbdname) parameter.
@@ -222,10 +237,10 @@ def run_module():
         psb_name=dict(type="list", elements="str", required=False),
         dbd_name=dict(type="list", elements="str", required=False),
         acb_lib=dict(type="str", required=True),
-        psb_lib=dict(type="list", required=True),
-        dbd_lib=dict(type="list", required=True),
-        reslib=dict(type="list", required=False),
-        steplib=dict(type="list", required=False),
+        psb_lib=dict(type="list", elements="str", required=True),
+        dbd_lib=dict(type="list", elements="str", required=True),
+        reslib=dict(type="list", elements="str", required=False),
+        steplib=dict(type="list", elements="str", required=False),
         build_psb=dict(type="bool", required=False, default=True),
     )
 

--- a/plugins/modules/ims_catalog_populate.py
+++ b/plugins/modules/ims_catalog_populate.py
@@ -992,8 +992,8 @@ def run_module():
     result = {}
     result["changed"] = False
 
-    parsed_args = catalog_parser.catalog_parser(module, module.params, result).validate_populate_input()
-    response = catalog.catalog(module, result, parsed_args).execute_catalog_populate()
+    parsed_args = catalog_parser(module, module.params, result).validate_populate_input()
+    response = catalog(module, result, parsed_args).execute_catalog_populate()
 
     if module.params['mode'] != "READ":
         result["changed"] = True

--- a/plugins/modules/ims_catalog_populate.py
+++ b/plugins/modules/ims_catalog_populate.py
@@ -13,7 +13,7 @@ DOCUMENTATION = r'''
 
 module: ims_catalog_populate
 short_description: Add records to the  IMS Catalog
-version_added: "2.9"
+version_added: "1.1.0"
 description:
   - The IMS Catalog Populate utility DFS3PU00 loads, inserts, or updates DBD and PSB instances
     into the database data sets of the IMS catalog from ACB library data sets.
@@ -62,6 +62,7 @@ options:
       - Points to an authorized library that contains the IMS SVC modules.
     type: list
     required: false
+    elements: str
   buffer_pool_param_dataset:
     description:
       - Defines the buffer pool parameters data set. This option is required if you are running the utility as a DLI.
@@ -710,6 +711,7 @@ options:
         defines various attributes of the IMS catalog that are required by the utility.
     type: list
     required: true
+    elements: str
   steplib:
     description:
       - Points to IMS.SDFSRESL, which contains the IMS nucleus and required IMS modules.
@@ -717,6 +719,7 @@ options:
       - The steplib input parameter to the module will take precedence over the value specified in the environment_vars.
     type: list
     required: False
+    elements: str
   sysabend:
     description:
       - Defines the dump data set. This defaults to = \*
@@ -960,25 +963,25 @@ from ansible_collections.ibm.ibm_zos_ims.plugins.module_utils.catalog_parser imp
 def run_module():
     module_args = dict(
         mode=dict(type="str", required=True, choices=['LOAD', 'UPDATE', 'READ']),
-        online_batch=dict(type="bool", required=False),
+        online_batch=dict(type="bool", required=False, default=False),
         ims_id=dict(type="str", required=False),
         dbrc=dict(type="bool", required=False),
         irlm_id=dict(type="str", required=False),
         modstat=dict(type="str", required=False),
-        reslib=dict(type="list", required=False),
+        reslib=dict(type="list", elements="str", required=False),
         buffer_pool_param_dataset=dict(type="str", required=False),
         primary_log_dataset=dict(type="dict", required=False),
         secondary_log_dataset=dict(type="dict", required=False),
-        psb_lib=dict(type="list", required=False),
-        dbd_lib=dict(type="list", required=False),
-        check_timestamp=dict(type="bool", required=False),
-        acb_lib=dict(type="list", required=True),
+        psb_lib=dict(type="list", elements="str", required=True),
+        dbd_lib=dict(type="list", elements="str", required=True),
+        check_timestamp=dict(type="bool", required=False, default=False),
+        acb_lib=dict(type="list", elements="str", required=True),
         bootstrap_dataset=dict(type="dict", required=False),
-        directory_datasets=dict(type="list", required=False),
+        directory_datasets=dict(type="list", elements="dict", required=False),
         temp_acb_dataset=dict(type="dict", required=False),
         directory_staging_dataset=dict(type="dict", required=False),
-        proclib=dict(type="list", required=False),
-        steplib=dict(type="list", required=False),
+        proclib=dict(type="list", elements="str", required=True),
+        steplib=dict(type="list", elements="str", required=False),
         sysabend=dict(type="str", required=False),
         control_statements=dict(type="dict", required=False)
     )

--- a/plugins/modules/ims_catalog_purge.py
+++ b/plugins/modules/ims_catalog_purge.py
@@ -13,7 +13,7 @@ DOCUMENTATION = r'''
 
 module: ims_catalog_purge
 short_description: Purge records from the IMS Catalog
-version_added: "2.9"
+version_added: "1.1.0"
 description:
   - The IMS Catalog Purge  utility DFS3PU10 removes the segments that represent a DBD or PSB instance,
     all instances of a DBD version, or an entire DBD or PSB record from the IMS catalog. You can also analyze
@@ -61,6 +61,7 @@ options:
       - Points to an authorized library that contains the IMS SVC modules.
     type: list
     required: false
+    elements: str
   buffer_pool_param_dataset:
     description:
       - Defines the buffer pool parameters data set. This option is required if you are running the utility as a DLI.
@@ -207,6 +208,7 @@ options:
         defines various attributes of the IMS catalog that are required by the utility.
     type: list
     required: true
+    elements: str
   steplib:
     description:
       - Points to IMS.SDFSRESL, which contains the IMS nucleus and required IMS modules.
@@ -214,6 +216,7 @@ options:
       - The steplib input parameter to the module will take precedence over the value specified in the environment_vars.
     type: list
     required: False
+    elements: str
   delete_dbd_by_version:
     description:
       - Delete DBD instances based on the specified name and version. If ANALYSIS mode is specified, it will
@@ -313,7 +316,7 @@ options:
       - The data set where delete statements are written to. Written either by the purge utility when specifying ANALYSIS or BOTH mode,
         or by the user when specifying PURGE mode.
     type: dict
-    required: true
+    required: false
     suboptions:
       dataset_name:
         description:
@@ -545,22 +548,22 @@ module = None
 
 def run_module():
     module_args = dict(
-        online_batch=dict(type="bool", required=False),
+        online_batch=dict(type="bool", required=False, default=False),
         ims_id=dict(type="str", required=False),
         dbrc=dict(type="bool", required=False),
         irlm_id=dict(type="str", required=False),
-        reslib=dict(type="list", required=False),
+        reslib=dict(type="list", elements="str", required=False),
         buffer_pool_param_dataset=dict(type="str", required=False),
-        primary_log_dataset=dict(type="dict", required=False),
-        psb_lib=dict(type="list", required=False),
-        dbd_lib=dict(type="list", required=False),
-        proclib=dict(type="list", required=False),
-        steplib=dict(type="list", required=False),
+        primary_log_dataset=dict(type="dict", required=True),
+        psb_lib=dict(type="list", elements="str", required=True),
+        dbd_lib=dict(type="list", elements="str", required=True),
+        proclib=dict(type="list", elements="str", required=True),
+        steplib=dict(type="list", elements="str", required=False),
         mode=dict(type="str", required=True, choices=['PURGE', 'BOTH', 'ANALYSIS']),
-        delete_dbd_by_version=dict(type="list", required=False),
+        delete_dbd_by_version=dict(type="list", elements="dict", required=False),
         sysut1=dict(type="dict", required=False),
-        update_retention_criteria=dict(type="list", required=False),
-        delete=dict(type="list", required=False),
+        update_retention_criteria=dict(type="list", elements="dict", required=False),
+        delete=dict(type="list", elements="dict", required=False),
         managed_acbs=dict(type="bool", required=False),
         resource_chkp_freq=dict(type="int", required=False)
     )

--- a/plugins/modules/ims_catalog_purge.py
+++ b/plugins/modules/ims_catalog_purge.py
@@ -574,8 +574,8 @@ def run_module():
     result = {}
     result["changed"] = False
 
-    parsed_args = catalog_parser.catalog_parser(module, module.params, result).validate_purge_input()
-    response = catalog.catalog(module, result, parsed_args).execute_catalog_purge()
+    parsed_args = catalog_parser(module, module.params, result).validate_purge_input()
+    response = catalog(module, result, parsed_args).execute_catalog_purge()
 
     if "DFS4518I" in result['content']:
         result["changed"] = True

--- a/plugins/modules/ims_dbd_gen.py
+++ b/plugins/modules/ims_dbd_gen.py
@@ -12,7 +12,7 @@ DOCUMENTATION = r'''
 ---
 module: ims_dbd_gen
 short_description: Generate IMS DBD
-version_added: "2.9"
+version_added: "1.0.0"
 description:
   - This ims_dbd_gen module generates IMS database descriptor (DBD) resource(s) to define a database so that it can be used by IMS application programs.
   - A database descriptor (DBD) is a DL/I control block describing the database, segments, fields, indexes and relationships.
@@ -76,13 +76,13 @@ options:
             - The src field can reference a PDS, PDSE member, sequential data set, or UNIX System Services file path.
             - If a PDS is specified, all members within the PDS will be treated as individual DBD source members to be processed.
           type: str
-          required: true
+          required: false
         location:
           description:
             - The DBD source location. Supported options are DATA_SET or USS. The default is DATA_SET.
             - The DATA_SET option can be used for a PDS, PDSE, or sequential data set.
           type: str
-          required: true
+          required: false
           default: DATA_SET
           choices:
             - DATA_SET
@@ -118,6 +118,7 @@ options:
         be used as the sys_lib at compile time.
     type: list
     required: true
+    elements: str
   dest:
     description:
       - The target output DBDLIB partitioned data set where the DBD members will be generated to.
@@ -277,7 +278,7 @@ def run_module():
                 member_list=dict(type='list', required=False),
                 dbd_name=dict(type='str', required=False))),
 
-        sys_lib=dict(type='list', required=True),
+        sys_lib=dict(type='list', elements='str', required=True),
         dest=dict(type='str', required=True))
 
     # TODO - enforce batch and single source params are mutually exclusive

--- a/plugins/modules/ims_dbrc.py
+++ b/plugins/modules/ims_dbrc.py
@@ -13,7 +13,7 @@ DOCUMENTATION = r'''
 module: ims_dbrc
 
 short_description: Submit IMS DBRC Commands
-version_added: "2.9"
+version_added: "1.1.0"
 
 description:
   - Use Database Recovery Control (DBRC) to record and manage information that is
@@ -29,6 +29,7 @@ options:
       - This is the well-formatted DBRC command to submit.
     type: list
     required: true
+    elements: str
   dbd_lib:
     description:
       - The data set that contains the descriptions for the databases that are under the control of DBRC.
@@ -80,6 +81,7 @@ options:
       - List of STEPLIB datasets that contain the IMS nucleus and the required action modules.
     type: list
     required: true
+    elements: str
 notes:
   - The I(steplib) parameter can also be specified in the target inventory's environment_vars.
   - The I(steplib) input parameter to the module will take precedence over the value specified in the environment_vars.
@@ -206,7 +208,7 @@ def get_step_lib_from_environment_var():
 def run_module():
     global module, result
     module_args = dict(
-        command=dict(type='list', required=True),
+        command=dict(type='list', elements="str", required=True),
         dbd_lib=dict(type='str', required=False),
         dynamic_allocation_dataset=dict(type='str', required=False),
         genjcl_input_dataset=dict(type='str', required=False),
@@ -215,7 +217,7 @@ def run_module():
         recon1=dict(type='str', required=False),
         recon2=dict(type='str', required=False),
         recon3=dict(type='str', required=False),
-        steplib=dict(type='list', required=True)
+        steplib=dict(type='list', elements="str", required=True)
     )
 
     result = dict(
@@ -267,7 +269,7 @@ def run_module():
                 result['msg'] = em.EMPTY_OUTPUT_MSG
 
             if response['error']:
-                print("An error occurred:", response['error'])
+                module.log("An error occurred:", response['error'])
 
             result['changed'] = False
             module.fail_json(**result)

--- a/plugins/modules/ims_dbrc.py
+++ b/plugins/modules/ims_dbrc.py
@@ -238,7 +238,7 @@ def run_module():
     if environ_step_lib:
         combined_step_lib = module.params['steplib'] + environ_step_lib
     try:
-        response = dbrc.dbrc(
+        response = dbrc(
             commands=module.params['command'],
             steplib=combined_step_lib,
             dbd_lib=module.params['dbd_lib'],

--- a/plugins/modules/ims_psb_gen.py
+++ b/plugins/modules/ims_psb_gen.py
@@ -12,7 +12,7 @@ DOCUMENTATION = r'''
 ---
 module: ims_psb_gen
 short_description: Generate IMS PSB
-version_added: "2.9"
+version_added: "1.0.0"
 description:
     - The Program Specification Block (PSB) Generation utility places the created PSB in the PSB library so that it can be used by IMS application programs.
 author:
@@ -74,7 +74,7 @@ options:
                     - The src field can reference a PDS, PDSE member, sequential data set, or UNIX System Services file path.
                     - If a PDS is specified, all members within the PDS will be treated as individual PSB source members to be processed.
                 type: str
-                required: true
+                required: false
             location:
                 description:
                     - The PSB source location, Supported options are DATA_SET or USS. The default is DATA_SET.
@@ -114,6 +114,7 @@ options:
                 be used as the sys_lib at compile time.
         type: list
         required: true
+        elements: str
     dest:
         description:
             - The target output PSBLIB partitioned data set in which the PSB members will be generated.
@@ -249,7 +250,7 @@ def run_module():
             )
         ),
 
-        sys_lib=dict(type='list', required=True),
+        sys_lib=dict(type='list', elements='str', required=True),
         dest=dict(type='str', required=True)
     )
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,8 +4,10 @@
 pytest==5.3.0
 pytest_mock==1.12.1
 mock==3.0.5
-ansible==2.9.6
+ansible-core==2.11.3
 pytest-ansible==2.2.2
 oyaml==0.9
 shellescape==3.8.1
 pylint>=2.5
+pycodestyle==2.7.0
+voluptuous==0.12.1

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,15 +1,6 @@
-tests/functional/modules/ims_psb_gen/combination/data/PWMGAT.psb no-smart-quotes # IBM-1047 encoding not recognized
-tests/functional/modules/ims_psb_gen/uss_file/data/PWMGAT.psb no-smart-quotes # IBM-1047 encoding not recognized
-tests/functional/modules/ims_psb_gen/uss_file/data/psbgen01 no-smart-quotes # IBM-1047 encoding not recognized
-tests/functional/modules/ims_psb_gen/combination/data/psbgen01 no-smart-quotes # IBM-1047 encoding not recognized
-tests/functional/modules/ims_dbd_gen/uss_file/data/WMGAT.dbd no-smart-quotes # IBM-1047 encoding not recognized
-tests/functional/modules/ims_dbd_gen/uss_file/data/dbdgen02 no-smart-quotes # IBM-1047 encoding not recognized
-tests/helpers/ztest.py pylint:syntax-error # known ansible-test issue
 playbook.sh shebang # ignore unexpected non-module shebang
-tests/run.sh shebang # ignore unexpected non-module shebang
 plugins/modules/ims_dbd_gen.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/ims_psb_gen.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/ims_acb_gen.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/ims_command.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
-plugins/modules/ims_acb_gen.py validate-modules:doc-choices-do-not-match-spec # we use our own checking for validation argument case.
 plugins/modules/ims_dbrc.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,0 +1,15 @@
+tests/functional/modules/ims_psb_gen/combination/data/PWMGAT.psb no-smart-quotes # IBM-1047 encoding not recognized
+tests/functional/modules/ims_psb_gen/uss_file/data/PWMGAT.psb no-smart-quotes # IBM-1047 encoding not recognized
+tests/functional/modules/ims_psb_gen/uss_file/data/psbgen01 no-smart-quotes # IBM-1047 encoding not recognized
+tests/functional/modules/ims_psb_gen/combination/data/psbgen01 no-smart-quotes # IBM-1047 encoding not recognized
+tests/functional/modules/ims_dbd_gen/uss_file/data/WMGAT.dbd no-smart-quotes # IBM-1047 encoding not recognized
+tests/functional/modules/ims_dbd_gen/uss_file/data/dbdgen02 no-smart-quotes # IBM-1047 encoding not recognized
+tests/helpers/ztest.py pylint:syntax-error # known ansible-test issue
+playbook.sh shebang # ignore unexpected non-module shebang
+tests/run.sh shebang # ignore unexpected non-module shebang
+plugins/modules/ims_dbd_gen.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/ims_psb_gen.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/ims_acb_gen.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/ims_command.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/ims_acb_gen.py validate-modules:doc-choices-do-not-match-spec # we use our own checking for validation argument case.
+plugins/modules/ims_dbrc.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0


### PR DESCRIPTION
##### SUMMARY
Removed redundant module call. Originally we had the following code (as a workaround for an Ansible import issue we encountered):
```
dbrc.dbrc(...)
```
It now appears this is redundant and we have made the following changes to the code
```
dbrc.dbrc(...) --> dbrc(...)
```
as well as for acbgen
```
acbgen.acbgen(...) --> acbgen(...)
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- [Bugfix Pull Request](https://jsw.ibm.com/browse/NAZARE-6190)

##### COMPONENT NAME
- ims_dbrc
- ims_acbgen

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
NOTE: This fix will only work with Ansible versions 2.10+ 