### PR TITLE
replace whitespace in JSON keys with underscore.

### DIFF
--- a/plugins/module_utils/ims_command_utils.py
+++ b/plugins/module_utils/ims_command_utils.py
@@ -104,7 +104,7 @@ If wideload.cmderr.0 /= '' Then
     Say '    "ims_member_messages": ['
     Do ix = 1 To wideload.cmderr.0
       Say '     {'
-      Say '        "Mbr name' ix '": ' '"'wideload.cmderr.ix.name'",'
+      Say '        "Mbr_name' ix '": ' '"'wideload.cmderr.ix.name'",'
       Say '        "type": "'wideload.cmderr.ix.typ'",'
       Say '        "styp": "'wideload.cmderr.ix.styp'",'
       Say '        "cmderr rc": "'wideload.cmderr.ix.rc'",'
@@ -216,8 +216,8 @@ If wideload.msgdata.name.0 /= '' Then
         Do
           If wideload.msgdata.msg.y.0 /= '' Then
             Do
-              Say '     "Mbr name' y'":' '"'wideload.msgdata.name.y'",'
-              Say '     "msg data":  ['
+              Say '     "Mbr_name' y'":' '"'wideload.msgdata.name.y'",'
+              Say '     "msg_data":  ['
               Do x = 1 To wideload.msgdata.msg.y.0
                 wideload.msgdata.msg.y.x = TRANSLATE(wideload.msgdata.msg.y.x, "'", '"') /* replace double quote with single */
                 data = wideload.msgdata.msg.y.x
@@ -230,7 +230,7 @@ If wideload.msgdata.name.0 /= '' Then
             End
           Else
             Do
-              Say '     "Mbr name' y'":' '"'wideload.msgdata.name.y'"'
+              Say '     "Mbr_name' y'":' '"'wideload.msgdata.name.y'"'
             End
         End
         Say '   }'


### PR DESCRIPTION
##### SUMMARY
The rexx script  builds JSON output that has whitespaces in the keys. This change replaces whitespace with underscore to help make the output more parsable.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- [Bugfix Pull Request](https://jsw.ibm.com/browse/NAZARE-5979)

##### COMPONENT NAME
ims_command_utils.py (module_utils)

##### ADDITIONAL INFORMATION
- Low risk, low impact change. Will run functional tests anyway to ensure nothing got affected.
- These keys are not being referenced anywhere else in the project.
