### PR TITLE
fix ims_catalog_populate bug.

### DIFF
--- a/plugins/module_utils/catalog.py
+++ b/plugins/module_utils/catalog.py
@@ -182,7 +182,7 @@ class catalog(object):
                 for i in self.parsed_args.get('acb_lib'):
                     acbDataset = DatasetDefinition(i)
                     acbDatasetList.append(acbDataset)
-                acbDDStatement = DDStatement("IMSACBA", acbDatasetList)
+                acbDDStatement = DDStatement("IMSACB01", acbDatasetList)
                 dDStatementList.append(acbDDStatement)
         # If check_timestamp is true, then we generate a dd statement for each dataset
             else:

--- a/plugins/modules/ims_catalog_populate.py
+++ b/plugins/modules/ims_catalog_populate.py
@@ -340,7 +340,7 @@ options:
         it will ignore the ACB with the duplicate name.
     type: bool
     required: false
-    default: false
+    default: true
   acb_lib:
     description:
       - Defines an ACB library data set that contains the ACB members that are used to populate the IMS catalog.
@@ -974,7 +974,7 @@ def run_module():
         secondary_log_dataset=dict(type="dict", required=False),
         psb_lib=dict(type="list", elements="str", required=True),
         dbd_lib=dict(type="list", elements="str", required=True),
-        check_timestamp=dict(type="bool", required=False, default=False),
+        check_timestamp=dict(type="bool", required=False, default=True),
         acb_lib=dict(type="list", elements="str", required=True),
         bootstrap_dataset=dict(type="dict", required=False),
         directory_datasets=dict(type="list", elements="dict", required=False),


### PR DESCRIPTION
##### SUMMARY
Fixes `ims_catalog_populate` module bug that was introduced this release. Also fixes an existing bug where
check_timestamp=false scenario for `ims_catalog_populate` was returning an error.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/ims_catalog_populate.py
plugins/module_utils/catalog.py

##### ADDITIONAL INFORMATION
Assigning a `false` default value to `check_timestamp` caused ACBLIB DDStatement to get incorrectly generated which was breaking the module call with the following error:

> DFS4461E NEITHER AN ACBLIB NOR A CATALOG IMPORT DATA SET IS SPECIFIED IN THE UTILITY JCL.

Testing:
- Ran ims collection sample against this change with `check_timestamp: false` and `check_timestamp` not defined in the playbook. Both playbook runs succeed.
- Running the change against CI/CD pipeline now.
<img width="1338" alt="Screen Shot 2021-10-27 at 10 20 56 AM" src="https://user-images.githubusercontent.com/29433053/139152134-6db8bd8d-035b-40c3-be2e-861bc26ab654.png">

<img width="1577" alt="Screen Shot 2021-10-27 at 10 38 08 AM" src="https://user-images.githubusercontent.com/29433053/139152143-e0472313-3d94-4b21-9278-225a623466c9.png">