### PR TITLE
Update ims_gen_utils.py

### DIFF
--- a/plugins/module_utils/ims_gen_utils.py
+++ b/plugins/module_utils/ims_gen_utils.py
@@ -328,7 +328,7 @@ def execute_gen_command(source, dest, syslib_list, run_command, module, result):
                         return src, return_code, return_text, failed
 
                     for item in source['member_list']:
-                        if type(item) == str:
+                        if isinstance(item, str):
                             # set target name same as src
                             src_member = item
                             target_name = item


### PR DESCRIPTION
type() not supported in python3.12, resolving sanity error - replaced by isinstance()


