### PR TITLE
Revert acbgen compression doc string changes

### DIFF
--- a/plugins/modules/ims_acb_gen.py
+++ b/plugins/modules/ims_acb_gen.py
@@ -36,13 +36,16 @@ options:
   compression:
     description:
       - PRECOMP,POSTCOMP, in any combination, cause the required in-place compression.
-      - The choices are not mutually exclusive -- PRECOMP or POSTCOMP or PRECOMP,POSTCOMP can be used
       - The default is none.
     type: str
     required: false
     choices:
+      - precomp
+      - postcomp
+      - precomp,postcomp
       - PRECOMP
       - POSTCOMP
+      - PRECOMP,POSTCOMP
   psb_name:
     description:
       - The name of the PSB(s). Specifies that blocks are built or deleted for all PSBs that are named on this control statement.

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -7,4 +7,3 @@ plugins/modules/ims_dbrc.py validate-modules:missing-gplv3-license # Licensed un
 plugins/modules/ims_catalog_populate.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/ims_catalog_purge.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/ims_ddl.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
-plugins/modules/ims_acb_gen.py validate-modules:doc-choices-do-not-match-spec

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -6,4 +6,3 @@ plugins/modules/ims_dbrc.py validate-modules:missing-gplv3-license # Licensed un
 plugins/modules/ims_catalog_populate.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/ims_catalog_purge.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/ims_ddl.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
-plugins/modules/ims_acb_gen.py validate-modules:doc-choices-do-not-match-spec

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -6,4 +6,3 @@ plugins/modules/ims_dbrc.py validate-modules:missing-gplv3-license # Licensed un
 plugins/modules/ims_catalog_populate.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/ims_catalog_purge.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/ims_ddl.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
-plugins/modules/ims_acb_gen.py validate-modules:doc-choices-do-not-match-spec

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -6,4 +6,3 @@ plugins/modules/ims_dbrc.py validate-modules:missing-gplv3-license # Licensed un
 plugins/modules/ims_catalog_populate.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/ims_catalog_purge.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/ims_ddl.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
-plugins/modules/ims_acb_gen.py validate-modules:doc-choices-do-not-match-spec

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -6,4 +6,3 @@ plugins/modules/ims_dbrc.py validate-modules:missing-gplv3-license # Licensed un
 plugins/modules/ims_catalog_populate.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/ims_catalog_purge.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/ims_ddl.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
-plugins/modules/ims_acb_gen.py validate-modules:doc-choices-do-not-match-spec

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -6,4 +6,3 @@ plugins/modules/ims_dbrc.py validate-modules:missing-gplv3-license # Licensed un
 plugins/modules/ims_catalog_populate.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/ims_catalog_purge.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/ims_ddl.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
-plugins/modules/ims_acb_gen.py validate-modules:doc-choices-do-not-match-spec

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -6,4 +6,3 @@ plugins/modules/ims_dbrc.py validate-modules:missing-gplv3-license # Licensed un
 plugins/modules/ims_catalog_populate.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/ims_catalog_purge.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/ims_ddl.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
-plugins/modules/ims_acb_gen.py validate-modules:doc-choices-do-not-match-spec

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -7,5 +7,3 @@ plugins/modules/ims_dbrc.py validate-modules:missing-gplv3-license # Licensed un
 plugins/modules/ims_catalog_populate.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/ims_catalog_purge.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/ims_ddl.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
-plugins/modules/ims_acb_gen.py validate-modules:doc-choices-do-not-match-spec
-


### PR DESCRIPTION
Remove acbgen compression doc string.
Remove validate-modules:doc-choices-do-not-match-spec from ignore files as it's no longer needed.